### PR TITLE
Add PIP_INDEX_URL env var to support custom index URL/mirror

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -130,6 +130,11 @@ a `.s2i/environment` file inside your source code repository.
     Set this variable to a non-empty value to inhibit the execution of 'manage.py migrate'
     when the produced image is run. This only affects Django projects.
 
+* **PIP_INDEX_URL**
+
+    Set this variable to use a custom index URL or mirror to download required packages
+    during build process. This only affects packages listed in requirements.txt.
+
 Source repository layout
 ------------------------
 

--- a/3.3/README.md
+++ b/3.3/README.md
@@ -130,6 +130,11 @@ file inside your source code repository.
     Set this variable to a non-empty value to inhibit the execution of 'manage.py migrate'
     when the produced image is run. This only affects Django projects.
 
+* **PIP_INDEX_URL**
+
+    Set this variable to use a custom index URL or mirror to download required packages
+    during build process. This only affects packages listed in requirements.txt.
+
 Source repository layout
 ------------------------
 

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -130,6 +130,11 @@ file inside your source code repository.
     Set this variable to a non-empty value to inhibit the execution of 'manage.py migrate'
     when the produced image is run. This only affects Django projects.
 
+* **PIP_INDEX_URL**
+
+    Set this variable to use a custom index URL or mirror to download required packages
+    during build process. This only affects packages listed in requirements.txt.
+
 Source repository layout
 ------------------------
 

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -130,6 +130,11 @@ file inside your source code repository.
     Set this variable to a non-empty value to inhibit the execution of 'manage.py migrate'
     when the produced image is run. This only affects Django projects.
 
+* **PIP_INDEX_URL**
+
+    Set this variable to use a custom index URL or mirror to download required packages
+    during build process. This only affects packages listed in requirements.txt.
+
 Source repository layout
 ------------------------
 


### PR DESCRIPTION
Currently, Python S2I images use default pypi.python.org to get all
required packages during deployment process. However, there is a need
to allow users to use custom index URL (mirror) to get the packages.
This option can speed up deployment process.

The assemble code is modified to check for PYPI_MIRROR env var and
then passes the env var into "pip install" command if it exists.

Signed-off-by: Vu Dinh <vdinh@redhat.com>