### PR TITLE
reduce max worker calculations

### DIFF
--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -24,9 +24,9 @@ function get_default_web_concurrency() {
     return
   fi
 
-  local max=$((NUMBER_OF_CORES*4))
-  # Require at least 40 MiB and additional 3 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 3))
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 40 MiB and additional 10 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 10))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -24,9 +24,9 @@ function get_default_web_concurrency() {
     return
   fi
 
-  local max=$((NUMBER_OF_CORES*4))
-  # Require at least 40 MiB and additional 5 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 5))
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 40 MiB and additional 10 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 10))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -24,9 +24,9 @@ function get_default_web_concurrency() {
     return
   fi
 
-  local max=$((NUMBER_OF_CORES*4))
-  # Require at least 43 MiB and additional 5 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 5))
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 43 MiB and additional 10 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 10))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -24,9 +24,9 @@ function get_default_web_concurrency() {
     return
   fi
 
-  local max=$((NUMBER_OF_CORES*4))
-  # Require at least 43 MiB and additional 4 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 4))
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 43 MiB and additional 10 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 10))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1351065

previous calculations were too aggressive, resulting in too many workers and overloading the container.

@rhcarvalho ptal
