### PR TITLE
Display custom PIP_INDEX_URL info

### DIFF
--- a/3.3/s2i/bin/assemble
+++ b/3.3/s2i/bin/assemble
@@ -15,7 +15,11 @@ echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
 if [[ -f requirements.txt ]]; then
-  echo "---> Installing dependencies ..."
+  if [ -n "$PIP_INDEX_URL" ]; then
+    echo "---> Installing dependencies via $PIP_INDEX_URL ..."
+  else
+    echo "---> Installing dependencies ..."
+  fi
   pip install --user -r requirements.txt
 fi
 

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -20,7 +20,11 @@ if [[ -f requirements.txt ]]; then
 fi
 
 if [[ -f setup.py ]]; then
-  echo "---> Installing application ..."
+  if [ -n "$PIP_INDEX_URL" ]; then
+    echo "---> Installing dependencies via $PIP_INDEX_URL ..."
+  else
+    echo "---> Installing dependencies ..."
+  fi
   python setup.py develop --user
 fi
 


### PR DESCRIPTION
The current PIP version (1.5.6) in Python 3.3 and 3.4 doesn't display
the repository link for non-PyPi during "pip install" step in the log
which may make debugging difficult.

The fix is added to display the non-PyPi repository link that is set
by users via PIP_INDEX_URL env var.

Bug 1357794
Link https://bugzilla.redhat.com/show_bug.cgi?id=1357794

Signed-off-by: Vu Dinh <vdinh@redhat.com>