### PR TITLE
Add numpy/scipy support + test

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.tags="builder,python,python27,rh-python27"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools python27-python-pip epel-release nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -22,7 +22,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/2.7/test/numpy-test-app/requirements.txt
+++ b/2.7/test/numpy-test-app/requirements.txt
@@ -1,0 +1,2 @@
+gunicorn
+numpy

--- a/2.7/test/numpy-test-app/wsgi.py
+++ b/2.7/test/numpy-test-app/wsgi.py
@@ -1,0 +1,7 @@
+import numpy
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type','text/plain')])
+    matrix = numpy.array([[1,2,3],[6,5,4],[7,8,8]])
+    matrix.dot(numpy.linalg.inv(matrix))
+    return [b"Hello World from numpy WSGI application!"]

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-27-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.3 applicati
       io.openshift.tags="builder,python,python33"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools epel-release nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools epel-release nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -22,7 +22,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.3/test/numpy-test-app/requirements.txt
+++ b/3.3/test/numpy-test-app/requirements.txt
@@ -1,0 +1,2 @@
+gunicorn
+numpy

--- a/3.3/test/numpy-test-app/wsgi.py
+++ b/3.3/test/numpy-test-app/wsgi.py
@@ -1,0 +1,7 @@
+import numpy
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type','text/plain')])
+    matrix = numpy.array([[1,2,3],[6,5,4],[7,8,8]])
+    matrix.dot(numpy.linalg.inv(matrix))
+    return [b"Hello World from numpy WSGI application!"]

--- a/3.3/test/run
+++ b/3.3/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-33-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
       io.openshift.tags="builder,python,python34,rh-python34"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip epel-release nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip epel-release nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -22,7 +22,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.4/test/numpy-test-app/requirements.txt
+++ b/3.4/test/numpy-test-app/requirements.txt
@@ -1,0 +1,2 @@
+gunicorn
+numpy

--- a/3.4/test/numpy-test-app/wsgi.py
+++ b/3.4/test/numpy-test-app/wsgi.py
@@ -1,0 +1,7 @@
+import numpy
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type','text/plain')])
+    matrix = numpy.array([[1,2,3],[6,5,4],[7,8,8]])
+    matrix.dot(numpy.linalg.inv(matrix))
+    return [b"Hello World from numpy WSGI application!"]

--- a/3.4/test/run
+++ b/3.4/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-34-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.5 applicati
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip epel-release nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip epel-release nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -22,7 +22,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip nss_wrapper httpd httpd-devel" && \
+    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.5/test/numpy-test-app/requirements.txt
+++ b/3.5/test/numpy-test-app/requirements.txt
@@ -1,0 +1,2 @@
+gunicorn
+numpy

--- a/3.5/test/numpy-test-app/wsgi.py
+++ b/3.5/test/numpy-test-app/wsgi.py
@@ -1,0 +1,7 @@
+import numpy
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type','text/plain')])
+    matrix = numpy.array([[1,2,3],[6,5,4],[7,8,8]])
+    matrix.dot(numpy.linalg.inv(matrix))
+    return [b"Hello World from numpy WSGI application!"]

--- a/3.5/test/run
+++ b/3.5/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-35-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"


### PR DESCRIPTION
This PR adds packages needed to succesfully install numpy and scipy in the image.

A simple test case has also been added. I have opted for testing numpy only, since scipy takes a long time to install.