### PR TITLE
Fix the wrong condition check for PIP_INDEX_URL in Python 3.4

### DIFF
--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -15,16 +15,16 @@ echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
 if [[ -f requirements.txt ]]; then
-  echo "---> Installing dependencies ..."
-  pip install --user -r requirements.txt
-fi
-
-if [[ -f setup.py ]]; then
   if [ -n "$PIP_INDEX_URL" ]; then
     echo "---> Installing dependencies via $PIP_INDEX_URL ..."
   else
     echo "---> Installing dependencies ..."
   fi
+  pip install --user -r requirements.txt
+fi
+
+if [[ -f setup.py ]]; then
+  echo "---> Installing application ..."
   python setup.py develop --user
 fi
 


### PR DESCRIPTION
The condition check for PIP_INDEX_URL in Python 3.4 is placed in a
wrong if-statement. It should be placed in requirements.txt if-statement,
not set.up one.

PR: Display custom PIP_INDEX_URL info (140)

Signed-off-by: Vu Dinh <vdinh@redhat.com>