### PR TITLE
Add tests for using uWSGI as the WSGI server. #164

### DIFF
--- a/2.7/test/run
+++ b/2.7/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-27-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django,numpy,app-home}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/2.7/test/uwsgi-test-app/app.py
+++ b/2.7/test/uwsgi-test-app/app.py
@@ -1,0 +1,3 @@
+import os
+
+os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/2.7/test/uwsgi-test-app/app.sh
+++ b/2.7/test/uwsgi-test-app/app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec uwsgi \
+    --http-socket :8080 \
+    --die-on-term \
+    --master \
+    --single-interpreter \
+    --enable-threads \
+    --threads=5 \
+    --thunder-lock \
+    --module wsgi

--- a/2.7/test/uwsgi-test-app/requirements.txt
+++ b/2.7/test/uwsgi-test-app/requirements.txt
@@ -1,0 +1,2 @@
+uWSGI
+Flask

--- a/2.7/test/uwsgi-test-app/wsgi.py
+++ b/2.7/test/uwsgi-test-app/wsgi.py
@@ -1,0 +1,9 @@
+from flask import Flask
+application = Flask(__name__)
+
+@application.route('/')
+def hello():
+    return b'Hello World from uWSGI hosted WSGI application!'
+
+if __name__ == '__main__':
+    application.run()

--- a/3.3/test/run
+++ b/3.3/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-33-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django,numpy,app-home}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.3/test/uwsgi-test-app/app.py
+++ b/3.3/test/uwsgi-test-app/app.py
@@ -1,0 +1,3 @@
+import os
+
+os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.3/test/uwsgi-test-app/app.sh
+++ b/3.3/test/uwsgi-test-app/app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec uwsgi \
+    --http-socket :8080 \
+    --die-on-term \
+    --master \
+    --single-interpreter \
+    --enable-threads \
+    --threads=5 \
+    --thunder-lock \
+    --module wsgi

--- a/3.3/test/uwsgi-test-app/requirements.txt
+++ b/3.3/test/uwsgi-test-app/requirements.txt
@@ -1,0 +1,2 @@
+uWSGI
+Flask

--- a/3.3/test/uwsgi-test-app/wsgi.py
+++ b/3.3/test/uwsgi-test-app/wsgi.py
@@ -1,0 +1,9 @@
+from flask import Flask
+application = Flask(__name__)
+
+@application.route('/')
+def hello():
+    return b'Hello World from uWSGI hosted WSGI application!'
+
+if __name__ == '__main__':
+    application.run()

--- a/3.4/test/run
+++ b/3.4/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-34-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django,numpy,app-home}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.4/test/uwsgi-test-app/app.py
+++ b/3.4/test/uwsgi-test-app/app.py
@@ -1,0 +1,3 @@
+import os
+
+os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.4/test/uwsgi-test-app/app.sh
+++ b/3.4/test/uwsgi-test-app/app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec uwsgi \
+    --http-socket :8080 \
+    --die-on-term \
+    --master \
+    --single-interpreter \
+    --enable-threads \
+    --threads=5 \
+    --thunder-lock \
+    --module wsgi

--- a/3.4/test/uwsgi-test-app/requirements.txt
+++ b/3.4/test/uwsgi-test-app/requirements.txt
@@ -1,0 +1,2 @@
+uWSGI
+Flask

--- a/3.4/test/uwsgi-test-app/wsgi.py
+++ b/3.4/test/uwsgi-test-app/wsgi.py
@@ -1,0 +1,9 @@
+from flask import Flask
+application = Flask(__name__)
+
+@application.route('/')
+def hello():
+    return b'Hello World from uWSGI hosted WSGI application!'
+
+if __name__ == '__main__':
+    application.run()

--- a/3.5/test/run
+++ b/3.5/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-35-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django,numpy,app-home}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.5/test/uwsgi-test-app/app.py
+++ b/3.5/test/uwsgi-test-app/app.py
@@ -1,0 +1,3 @@
+import os
+
+os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.5/test/uwsgi-test-app/app.sh
+++ b/3.5/test/uwsgi-test-app/app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+exec uwsgi \
+    --http-socket :8080 \
+    --die-on-term \
+    --master \
+    --single-interpreter \
+    --enable-threads \
+    --threads=5 \
+    --thunder-lock \
+    --module wsgi

--- a/3.5/test/uwsgi-test-app/requirements.txt
+++ b/3.5/test/uwsgi-test-app/requirements.txt
@@ -1,0 +1,2 @@
+uWSGI
+Flask

--- a/3.5/test/uwsgi-test-app/wsgi.py
+++ b/3.5/test/uwsgi-test-app/wsgi.py
@@ -1,0 +1,9 @@
+from flask import Flask
+application = Flask(__name__)
+
+@application.route('/')
+def hello():
+    return b'Hello World from uWSGI hosted WSGI application!'
+
+if __name__ == '__main__':
+    application.run()


### PR DESCRIPTION
These are tests for running uWSGI as WSGI server.

This is set up to jump from ``app.py`` to ``app.sh``, which then runs ``uwsgi``. When #126 is implemented, this will also serve as test of having ``app.sh`` and the ``app.py`` file will not be needed.

A merge conflict will occur for the changes to ``run`` scripts with #162. One or the other will need to resolve the conflict depending on order PR is merged.