### PR TITLE
WIP: APP_HOME now changes working directory before running app

### DIFF
--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -15,6 +15,12 @@ function should_migrate() {
   is_django_installed && [[ -z "$DISABLE_MIGRATE" ]]
 }
 
+# Utility function to update PYTHONPATH and change cwd
+function change_cwd() {
+  export PYTHONPATH=${PYTHONPATH:-}:`pwd`
+  cd $1
+}
+
 # Guess the number of workers according to the number of cores
 function get_default_web_concurrency() {
   limit_vars=$(cgroup-limits)
@@ -32,17 +38,19 @@ function get_default_web_concurrency() {
   echo $default
 }
 
+APP_HOME=${APP_HOME:-.}
+
 app_file_check="${APP_FILE-}"
-APP_FILE="${APP_FILE:-app.py}"
+APP_FILE="${APP_FILE:-${APP_HOME}/app.py}"
 if [[ -f "$APP_FILE" ]]; then
   echo "---> Running application from Python script ($APP_FILE) ..."
-  exec python "$APP_FILE"
+  change_cwd $APP_HOME
+  exec python $(basename $APP_FILE)
 else
   test -n "$app_file_check" && (>&2 echo "ERROR: file '$app_file_check' not found.") && exit 1
 fi
 
-APP_HOME=${APP_HOME:-.}
-# Look for 'manage.py' in the directory specified by APP_HOME, or the current direcotry
+# Look for 'manage.py' in the directory specified by APP_HOME, or the current directory
 manage_file=$APP_HOME/manage.py
 
 if should_migrate; then
@@ -58,18 +66,21 @@ fi
 if is_gunicorn_installed; then
   if [[ -z "$APP_MODULE" ]]; then
     # Look only in the directory specified by APP_HOME, or the current directory
-    # replace all "/" with ".", remove leading "." and ".py" suffix
-    APP_MODULE=$(find $APP_HOME -maxdepth 1 -type f -name 'wsgi.py' | sed 's:/:.:g;s:^\.\+::;s:\.py$::')
+    APP_MODULE=$(find $APP_HOME -maxdepth 1 -type f -name 'wsgi.py')
+    APP_MODULE=${APP_MODULE:+wsgi}
   fi
 
   if [[ -z "$APP_MODULE" && -f setup.py ]]; then
     APP_MODULE="$(python setup.py --name)"
+    #FIXME: A bit counterintuitive?
+    [[ $APP_MODULE ]] && APP_HOME=.
   fi
 
   if [[ "$APP_MODULE" ]]; then
     export WEB_CONCURRENCY=${WEB_CONCURRENCY:-$(get_default_web_concurrency)}
 
     echo "---> Serving application with gunicorn ($APP_MODULE) ..."
+    change_cwd $APP_HOME
     exec gunicorn "$APP_MODULE" --bind=0.0.0.0:8080 --access-logfile=- --config "$APP_CONFIG"
   fi
 fi
@@ -79,7 +90,8 @@ if is_django_installed; then
     echo "---> Serving application with 'manage.py runserver' ..."
     echo "WARNING: this is NOT a recommended way to run you application in production!"
     echo "Consider using gunicorn or some other production web server."
-    exec python "$manage_file" runserver 0.0.0.0:8080
+    change_cwd $APP_HOME
+    exec python manage.py runserver 0.0.0.0:8080
   else
     echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
     echo "Skipped 'python manage.py runserver'."

--- a/3.5/test/app-home-test-app/lib.py
+++ b/3.5/test/app-home-test-app/lib.py
@@ -1,0 +1,2 @@
+def hello_world():
+    return [b"Hello World from app-home WSGI application!"]

--- a/3.5/test/app-home-test-app/project/wsgi.py
+++ b/3.5/test/app-home-test-app/project/wsgi.py
@@ -1,3 +1,6 @@
+# Import to test properly set PYTHONPATH
+from lib import hello_world
+
 def application(environ, start_response):
     start_response('200 OK', [('Content-Type','text/plain')])
-    return [b"Hello World from app-home WSGI application!"]
+    return hello_world()


### PR DESCRIPTION
This PR modifies the APP_HOME variable feature in a number of ways.
Currently, the APP_HOME variable was only used as a point from which to do checks specific to assemble/run scripts. With this PR the scripts are now changing their current working directory to what is provided inside APP_HOME (+ appending old working directory to PYTHONPATH) before calling their respective applications in order to allow checks run from the appliaction to be done against APP_HOME.

As for the work in progress tag - I am at loss on how this should work with other application-path-modifying variables like APP_FILE or APP_MODULE. For APP_FILE, for the time being I have set them to be mutually exclusive as that made the most sense for me, but for APP_MODULE is a little bit different as it can be also set via `setup.py`. Taking this into account the script is now setting APP_HOME to its default value if APP_MODULE is found via `setup.py`. This seems however a bit counterinuitive to me so I would welcome some other suggestions.

@grahamdumpleton PTAL

Related: #134 #166 