### PR TITLE
Use centos/ namespaced s2i base image

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides a Python 2.7 environment you can use to run your Python
 # applications.
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides a Python 3.4 environment you can use to run your Python
 # applications.
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides a Python 3.5 environment you can use to run your Python
 # applications.
-FROM openshift/base-centos7
+FROM centos/s2i-base-centos7
 
 MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 


### PR DESCRIPTION
For centos/ namespaced images use centos/ namespaced s2i base image. This image is based on https://github.com/sclorg/s2i-base-container/ and is built by coreservices-jenkins maintained by RHSCL team.

@hhorak @bparees Please take a look and merge.