### PR TITLE
Add support for app.sh script so have easy control over how application launched.

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -214,7 +214,7 @@ following ways, in precedence order:
   This is the most general way of executing your application. It will be
   used in the case where you specify a path to an executable script file
   via the `APP_SCRIPT` environment variable, defaulting to a file named
-  `app.sh` if it exists. The script is executed directory to launch your
+  `app.sh` if it exists. The script is executed directly to launch your
   application.
 
 Hot deploy

--- a/2.7/README.md
+++ b/2.7/README.md
@@ -92,6 +92,12 @@ Environment variables
 To set these environment variables, you can place them as a key value pair into
 a `.s2i/environment` file inside your source code repository.
 
+* **APP_SCRIPT**
+
+    Used to run the application from a script file.
+    This should be a path to a script file (defaults to `app.sh`) that will be
+    run to start the application.
+
 * **APP_FILE**
 
     Used to run the application from a Python script.
@@ -197,10 +203,19 @@ following ways, in precedence order:
 
 * **Python script**
 
-  This is the most general way of executing your application. It will be used
-  in the case where you specify a path to a Python script via the `APP_FILE` environment
-  variable, defaulting to a file named `app.py` if it exists. The script is
-  passed to a regular Python interpreter to launch your application.
+  This would be used where you provide a Python code file for running you
+  application. It will be used in the case where you specify a path to a
+  Python script via the `APP_FILE` environment variable, defaulting to a
+  file named `app.py` if it exists. The script is passed to a regular
+  Python interpreter to launch your application.
+
+* **Application script file**
+
+  This is the most general way of executing your application. It will be
+  used in the case where you specify a path to an executable script file
+  via the `APP_SCRIPT` environment variable, defaulting to a file named
+  `app.sh` if it exists. The script is executed directory to launch your
+  application.
 
 Hot deploy
 ---------------------

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -99,5 +99,5 @@ if is_django_installed; then
 fi
 
 >&2 echo "ERROR: don't know how to run your application."
->&2 echo "Please set either APP_MODULE or APP_FILE environment variables, or create a file 'app.py' to launch your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
 exit 1

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -32,6 +32,18 @@ function get_default_web_concurrency() {
   echo $default
 }
 
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  exec "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
 app_file_check="${APP_FILE-}"
 APP_FILE="${APP_FILE:-app.py}"
 if [[ -f "$APP_FILE" ]]; then

--- a/2.7/test/uwsgi-test-app/app.py
+++ b/2.7/test/uwsgi-test-app/app.py
@@ -1,3 +1,0 @@
-import os
-
-os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -99,5 +99,5 @@ if is_django_installed; then
 fi
 
 >&2 echo "ERROR: don't know how to run your application."
->&2 echo "Please set either APP_MODULE or APP_FILE environment variables, or create a file 'app.py' to launch your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
 exit 1

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -32,6 +32,18 @@ function get_default_web_concurrency() {
   echo $default
 }
 
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  exec "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
 app_file_check="${APP_FILE-}"
 APP_FILE="${APP_FILE:-app.py}"
 if [[ -f "$APP_FILE" ]]; then

--- a/3.3/test/uwsgi-test-app/app.py
+++ b/3.3/test/uwsgi-test-app/app.py
@@ -1,3 +1,0 @@
-import os
-
-os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -92,6 +92,12 @@ Environment variables
 To set these environment variables, you can place them as a key value pair into a `.s2i/environment`
 file inside your source code repository.
 
+* **APP_SCRIPT**
+
+    Used to run the application from a script file.
+    This should be a path to a script file (defaults to `app.sh`) that will be
+    run to start the application.
+
 * **APP_FILE**
 
     Used to run the application from a Python script.
@@ -197,10 +203,19 @@ following ways, in precedence order:
 
 * **Python script**
 
-  This is the most general way of executing your application. It will be used
-  in the case where you specify a path to a Python script via the `APP_FILE` environment
-  variable, defaulting to a file named `app.py` if it exists. The script is
-  passed to a regular Python interpreter to launch your application.
+  This would be used where you provide a Python code file for running you
+  application. It will be used in the case where you specify a path to a
+  Python script via the `APP_FILE` environment variable, defaulting to a
+  file named `app.py` if it exists. The script is passed to a regular
+  Python interpreter to launch your application.
+
+* **Application script file**
+
+  This is the most general way of executing your application. It will be
+  used in the case where you specify a path to an executable script file
+  via the `APP_SCRIPT` environment variable, defaulting to a file named
+  `app.sh` if it exists. The script is executed directory to launch your
+  application.
 
 Hot deploy
 ---------------------

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -214,7 +214,7 @@ following ways, in precedence order:
   This is the most general way of executing your application. It will be
   used in the case where you specify a path to an executable script file
   via the `APP_SCRIPT` environment variable, defaulting to a file named
-  `app.sh` if it exists. The script is executed directory to launch your
+  `app.sh` if it exists. The script is executed directly to launch your
   application.
 
 Hot deploy

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -99,5 +99,5 @@ if is_django_installed; then
 fi
 
 >&2 echo "ERROR: don't know how to run your application."
->&2 echo "Please set either APP_MODULE or APP_FILE environment variables, or create a file 'app.py' to launch your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
 exit 1

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -32,6 +32,18 @@ function get_default_web_concurrency() {
   echo $default
 }
 
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  exec "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
 app_file_check="${APP_FILE-}"
 APP_FILE="${APP_FILE:-app.py}"
 if [[ -f "$APP_FILE" ]]; then

--- a/3.4/test/uwsgi-test-app/app.py
+++ b/3.4/test/uwsgi-test-app/app.py
@@ -1,3 +1,0 @@
-import os
-
-os.execl('/opt/app-root/src/app.sh', 'uwsgi')

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -92,6 +92,12 @@ Environment variables
 To set these environment variables, you can place them as a key value pair into a `.s2i/environment`
 file inside your source code repository.
 
+* **APP_SCRIPT**
+
+    Used to run the application from a script file.
+    This should be a path to a script file (defaults to `app.sh`) that will be
+    run to start the application.
+
 * **APP_FILE**
 
     Used to run the application from a Python script.
@@ -197,10 +203,19 @@ following ways, in precedence order:
 
 * **Python script**
 
-  This is the most general way of executing your application. It will be used
-  in the case where you specify a path to a Python script via the `APP_FILE` environment
-  variable, defaulting to a file named `app.py` if it exists. The script is
-  passed to a regular Python interpreter to launch your application.
+  This would be used where you provide a Python code file for running you
+  application. It will be used in the case where you specify a path to a
+  Python script via the `APP_FILE` environment variable, defaulting to a
+  file named `app.py` if it exists. The script is passed to a regular
+  Python interpreter to launch your application.
+
+* **Application script file**
+
+  This is the most general way of executing your application. It will be
+  used in the case where you specify a path to an executable script file
+  via the `APP_SCRIPT` environment variable, defaulting to a file named
+  `app.sh` if it exists. The script is executed directory to launch your
+  application.
 
 Hot deploy
 ---------------------

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -214,7 +214,7 @@ following ways, in precedence order:
   This is the most general way of executing your application. It will be
   used in the case where you specify a path to an executable script file
   via the `APP_SCRIPT` environment variable, defaulting to a file named
-  `app.sh` if it exists. The script is executed directory to launch your
+  `app.sh` if it exists. The script is executed directly to launch your
   application.
 
 Hot deploy

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -99,5 +99,5 @@ if is_django_installed; then
 fi
 
 >&2 echo "ERROR: don't know how to run your application."
->&2 echo "Please set either APP_MODULE or APP_FILE environment variables, or create a file 'app.py' to launch your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
 exit 1

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -32,6 +32,18 @@ function get_default_web_concurrency() {
   echo $default
 }
 
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  exec "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
 app_file_check="${APP_FILE-}"
 APP_FILE="${APP_FILE:-app.py}"
 if [[ -f "$APP_FILE" ]]; then

--- a/3.5/test/uwsgi-test-app/app.py
+++ b/3.5/test/uwsgi-test-app/app.py
@@ -1,3 +1,0 @@
-import os
-
-os.execl('/opt/app-root/src/app.sh', 'uwsgi')


### PR DESCRIPTION
This address issue https://github.com/sclorg/s2i-python-container/issues/126.

Note that you should merge change https://github.com/sclorg/s2i-python-container/pull/165 first as this depends on the test case added in that for uWSGI, which uses an ``app.sh`` file executed from an ``app.py`` file. When the change here is then merged, the ``app.sh`` file in the test will take precedence and the ``app.sh`` will be executed directly with ``app.py`` being bypassed.

Note that this change doesn't do anything about ``APP_HOME`` as existing code didn't do anything with ``APP_HOME`` for ``app.py`` either. Arguably it should, but this is being dealt with in separate issues and PR.

Also note that although the change uses ``APP_SCRIPT`` and refers to it as application script file, encouraging it as being used for a shell script, technically it could be any executable script file, or even a compiled application. A generic name for the environment variable could be used such as ``APP_PROGRAM`` if really want to reflect that, but probably better to encourage it being just used for a shell script which then in turn can execute anything.