### PR TITLE
Add required packages for SAML2

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools 
-	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools \ 
-	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,7 +15,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.tags="builder,python,python27,rh-python27"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools 
+    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools \ 
 	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -15,7 +15,8 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
       io.openshift.tags="builder,python,python27,rh-python27"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools 
+	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -25,7 +25,8 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -15,7 +15,8 @@ LABEL io.k8s.description="Platform for building and running Python 3.3 applicati
       io.openshift.tags="builder,python,python33"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools nss_wrapper httpd httpd-devel \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.3 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.3/Dockerfile
+++ b/3.3/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.3 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -25,7 +25,8 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.3/Dockerfile.rhel7
+++ b/3.3/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python33 python33-python-devel python33-python-setuptools python33-python-pip nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -15,7 +15,8 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
       io.openshift.tags="builder,python,python34,rh-python34"
 
 RUN yum install -y centos-release-scl && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -16,7 +16,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.4 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -25,7 +25,8 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip nss_wrapper httpd httpd-devel \
-	atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -16,7 +16,8 @@ LABEL io.k8s.description="Platform for building and running Python 3.5 applicati
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
-    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
+	 nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.5 applicati
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
-	 nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	 nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -17,7 +17,7 @@ LABEL io.k8s.description="Platform for building and running Python 3.5 applicati
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
-	 nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	 nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -25,7 +25,8 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
-    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran" && \
+    INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -26,7 +26,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="rh-python35 rh-python35-python-devel rh-python35-python-setuptools rh-python35-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl openssl-devel" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.


### PR DESCRIPTION
pySAML2 requires several packages, one of them (python-cryptography) requires openssl-devel, libffi (cffi) and xmlsec1 (which depends on the missing libltdl).
To my knowledge there are other packages requiring cffi and cryptography, thus this change should benefit everyone using them, while adding only a few Mb to the image.