### PR TITLE
Increased the assumed memory consumption.

### DIFF
--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -25,8 +25,8 @@ function get_default_web_concurrency() {
   fi
 
   local max=$((NUMBER_OF_CORES*2))
-  # Require at least 40 MiB and additional 10 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 10))
+  # Require at least 40 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -25,8 +25,8 @@ function get_default_web_concurrency() {
   fi
 
   local max=$((NUMBER_OF_CORES*2))
-  # Require at least 40 MiB and additional 10 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 10))
+  # Require at least 40 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -25,8 +25,8 @@ function get_default_web_concurrency() {
   fi
 
   local max=$((NUMBER_OF_CORES*2))
-  # Require at least 43 MiB and additional 10 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 10))
+  # Require at least 43 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -25,8 +25,8 @@ function get_default_web_concurrency() {
   fi
 
   local max=$((NUMBER_OF_CORES*2))
-  # Require at least 43 MiB and additional 10 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 10))
+  # Require at least 43 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   echo $default


### PR DESCRIPTION
Running the OpenShift recommended example:
https://github.com/openshift/django-ex

results in subtantially more memory consumption than the assumed '10M'.

This means that running on a shared platform where the memory/cpu ratio may
seem strange due to memory quotas (for example '8' CPUs but '512M' RAM) we
can end up spawning far more workers than we have memory for.  Resulting in
new workers being constantly killed, and high disk IO usage as the workers
keep respawning.

Note: While Docker can support limiting the number of CPUs seen, currently
Kubernetes and OpenShift do not support this.