### PR TITLE
RFC: Add npm for front-end development

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 EXPOSE 8080
 
 ENV PYTHON_VERSION=2.7 \
-    PATH=$HOME/.local/bin/:$PATH \
+    PATH=$HOME/.local/bin/:/opt/app-root/node_modules/.bin:$PATH \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
@@ -21,7 +21,7 @@ LABEL io.k8s.description="Platform for building and running Python 2.7 applicati
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools \ 
-	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	python27-python-pip nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl rh-nodejs4-npm" && \
     yum install -y --setopt=tsflags=nodocs --enablerepo=centosplus $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove centos-logos (httpd dependency, ~20MB of graphics) to keep image

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -5,7 +5,7 @@ FROM rhscl/s2i-base-rhel7
 EXPOSE 8080
 
 ENV PYTHON_VERSION=2.7 \
-    PATH=$HOME/.local/bin/:$PATH \
+    PATH=$HOME/.local/bin/:/opt/app-root/node_modules/.bin:$PATH \
     PYTHONIOENCODING=UTF-8 \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
@@ -30,7 +30,7 @@ RUN yum repolist > /dev/null && \
     yum-config-manager --enable rhel-7-server-ose-3.2-rpms && \
     yum-config-manager --disable epel >/dev/null || : && \
     INSTALL_PKGS="python27 python27-python-devel python27-python-setuptools python27-python-pip \
-	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+	nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran libffi-devel libtool-ltdl rh-nodejs4-npm" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos (httpd dependency) to keep image size smaller.

--- a/2.7/README.md
+++ b/2.7/README.md
@@ -162,6 +162,7 @@ a `.s2i/environment` file inside your source code repository.
     [workers](http://docs.gunicorn.org/en/stable/settings.html#workers). By
     default, this is set to the number of available cores times 4.
 
+
 Source repository layout
 ------------------------
 
@@ -180,6 +181,13 @@ However, if these files exist they will affect the behavior of the build process
   dependencies, as documented
   [here](https://packaging.python.org/en/latest/distributing.html#setup-py).
   For most projects, it is sufficient to simply use `requirements.txt`.
+
+
+* **package.json**
+
+  List of dependencies to be installed with `npm`. The format is documented
+  [here](https://docs.npmjs.com/files/package.json).
+
 
 
 Run strategies

--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -55,6 +55,12 @@ if should_collectstatic; then
   )
 fi
 
+# npm
+if [[ -f package.json ]]; then
+  echo "---> Installing npm modules ..."
+  npm install
+fi
+
 # Fix source directory permissions
 fix-permissions ./
 # set permissions for any installed artifacts

--- a/2.7/test/npm-test-app/.gitignore
+++ b/2.7/test/npm-test-app/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/2.7/test/npm-test-app/local_module/package.json
+++ b/2.7/test/npm-test-app/local_module/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "local_module",
+  "description": "This module is meant as an installation test only",
+  "version": "1.0.0"
+}

--- a/2.7/test/npm-test-app/package.json
+++ b/2.7/test/npm-test-app/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "local_module": "file:local_module"
+  }
+}

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-openshift/python-27-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi,locale}-test-app)
+declare -a WEB_APPS=({standalone,setup,django,numpy,app-home,uwsgi,locale,npm}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"
@@ -163,6 +163,20 @@ test_connection() {
     sleep $sleep_time
   done
   return $result
+}
+
+# !TODO: This still needs to be called
+test_npm_application() {
+  # Verify that NPM packages from package.json are installed
+  local_module_name="local_module"
+  npm_packages="$(npm list | grep $local_module_name)"
+
+  if [[ $npm_packages != *"$local_module_name"* ]]; then
+    echo "ERROR[Npm modules not installed]"
+    return 1
+  else
+    return 0
+  fi
 }
 
 test_application() {


### PR DESCRIPTION
* Following the commit on [redhat-developer/s2i-dotnetcore](https://github.com/redhat-developer/s2i-dotnetcore/commit/b8992565ca6f2724103cfdfbc049a1806929bfe4),  adding npm to the images allows for modern web applications to rely on javascript tools to build the app.

Currently it's hard (if not impossible) to pull in node and npm during build time, it takes too long and often times out. However, typically, CSS and JS files need pre-deployment processing such bundling, minifying, etc. 

In line with redhat-developer/s2i-dotnetcore#35, it would be better to avoid referring new developers to "Create Your Own Image" guides and instead provide npm directly.

This PR is serves both as an RFC and as a starting point for the proposal.