### PR TITLE
Skip default assignment to APP_FILE if it is set to null

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -95,13 +95,13 @@ a `.s2i/environment` file inside your source code repository.
 * **APP_SCRIPT**
 
     Used to run the application from a script file.
-    This should be a path to a script file (defaults to `app.sh`) that will be
+    This should be a path to a script file (defaults to `app.sh` unless set to null) that will be
     run to start the application.
 
 * **APP_FILE**
 
     Used to run the application from a Python script.
-    This should be a path to a Python file (defaults to `app.py`) that will be
+    This should be a path to a Python file (defaults to `app.py` unless set to null) that will be
     passed to the Python interpreter to start the application.
 
 * **APP_MODULE**

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -45,7 +45,7 @@ else
 fi
 
 app_file_check="${APP_FILE-}"
-APP_FILE="${APP_FILE:-app.py}"
+APP_FILE="${APP_FILE-app.py}"
 if [[ -f "$APP_FILE" ]]; then
   echo "---> Running application from Python script ($APP_FILE) ..."
   exec python "$APP_FILE"

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -33,7 +33,7 @@ function get_default_web_concurrency() {
 }
 
 app_script_check="${APP_SCRIPT-}"
-APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
 if [[ -f "$APP_SCRIPT" ]]; then
   echo "---> Running application from script ($APP_SCRIPT) ..."
   if [[ "$APP_SCRIPT" != /* ]]; then

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -45,7 +45,7 @@ else
 fi
 
 app_file_check="${APP_FILE-}"
-APP_FILE="${APP_FILE:-app.py}"
+APP_FILE="${APP_FILE-app.py}"
 if [[ -f "$APP_FILE" ]]; then
   echo "---> Running application from Python script ($APP_FILE) ..."
   exec python "$APP_FILE"

--- a/3.3/s2i/bin/run
+++ b/3.3/s2i/bin/run
@@ -33,7 +33,7 @@ function get_default_web_concurrency() {
 }
 
 app_script_check="${APP_SCRIPT-}"
-APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
 if [[ -f "$APP_SCRIPT" ]]; then
   echo "---> Running application from script ($APP_SCRIPT) ..."
   if [[ "$APP_SCRIPT" != /* ]]; then

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -95,13 +95,13 @@ file inside your source code repository.
 * **APP_SCRIPT**
 
     Used to run the application from a script file.
-    This should be a path to a script file (defaults to `app.sh`) that will be
+    This should be a path to a script file (defaults to `app.sh` unless set to null) that will be
     run to start the application.
 
 * **APP_FILE**
 
     Used to run the application from a Python script.
-    This should be a path to a Python file (defaults to `app.py`) that will be
+    This should be a path to a Python file (defaults to `app.py` unless set to null) that will be
     passed to the Python interpreter to start the application.
 
 * **APP_MODULE**

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -45,7 +45,7 @@ else
 fi
 
 app_file_check="${APP_FILE-}"
-APP_FILE="${APP_FILE:-app.py}"
+APP_FILE="${APP_FILE-app.py}"
 if [[ -f "$APP_FILE" ]]; then
   echo "---> Running application from Python script ($APP_FILE) ..."
   exec python "$APP_FILE"

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -33,7 +33,7 @@ function get_default_web_concurrency() {
 }
 
 app_script_check="${APP_SCRIPT-}"
-APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
 if [[ -f "$APP_SCRIPT" ]]; then
   echo "---> Running application from script ($APP_SCRIPT) ..."
   if [[ "$APP_SCRIPT" != /* ]]; then

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -95,13 +95,13 @@ file inside your source code repository.
 * **APP_SCRIPT**
 
     Used to run the application from a script file.
-    This should be a path to a script file (defaults to `app.sh`) that will be
+    This should be a path to a script file (defaults to `app.sh` unless set to null) that will be
     run to start the application.
 
 * **APP_FILE**
 
     Used to run the application from a Python script.
-    This should be a path to a Python file (defaults to `app.py`) that will be
+    This should be a path to a Python file (defaults to `app.py` unless set to null) that will be
     passed to the Python interpreter to start the application.
 
 * **APP_MODULE**

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -45,7 +45,7 @@ else
 fi
 
 app_file_check="${APP_FILE-}"
-APP_FILE="${APP_FILE:-app.py}"
+APP_FILE="${APP_FILE-app.py}"
 if [[ -f "$APP_FILE" ]]; then
   echo "---> Running application from Python script ($APP_FILE) ..."
   exec python "$APP_FILE"

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -33,7 +33,7 @@ function get_default_web_concurrency() {
 }
 
 app_script_check="${APP_SCRIPT-}"
-APP_SCRIPT="${APP_SCRIPT:-app.sh}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
 if [[ -f "$APP_SCRIPT" ]]; then
   echo "---> Running application from script ($APP_SCRIPT) ..."
   if [[ "$APP_SCRIPT" != /* ]]; then


### PR DESCRIPTION
If APP_FILE is set to any value including null ( APP_FILE= ) then the default
assignment to value of `app.py` is skipped.

This will allow people to have a script named `app.py` but run it in a
different manner (e.g. through gunicorn—fixes #190) by setting APP_FILE to null.