### PR TITLE
Update Dockerfiles

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -2,8 +2,6 @@
 # applications.
 FROM centos/s2i-base-centos7
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 EXPOSE 8080
 
 ENV PYTHON_VERSION=2.7 \
@@ -28,7 +26,12 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 2.7" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python27,rh-python27"
+      io.openshift.tags="builder,python,python27,rh-python27" \
+      com.redhat.component="python27-docker" \
+      name="centos/python-27-centos7" \
+      version="2.7" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="libjpeg-turbo libjpeg-turbo-devel python27 python27-python-devel python27-python-setuptools \ 

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -26,14 +26,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 2.7" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python27,rh-python27"
-
-# Labels consumed by Red Hat build service.
-LABEL com.redhat.component="python27-docker" \
+      io.openshift.tags="builder,python,python27,rh-python27" \
+      com.redhat.component="python27-docker" \
       name="rhscl/python-27-rhel7" \
       version="2.7" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -28,7 +28,12 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 3.4" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python34,rh-python34"
+      io.openshift.tags="builder,python,python34,rh-python34" \
+      com.redhat.component="python34-docker" \
+      name="centos/python-34-centos7" \
+      version="3.4" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl && \
     INSTALL_PKGS="rh-python34 rh-python34-python-devel rh-python34-python-setuptools rh-python34-python-pip \

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -26,14 +26,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 3.4" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python34,rh-python34"
-
-# Labels consumed by Red Hat build service.
-LABEL com.redhat.component="rh-python34-docker" \
+      io.openshift.tags="builder,python,python34,rh-python34" \
+      com.redhat.component="rh-python34-docker" \
       name="rhscl/python-34-rhel7" \
       version="3.4" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -28,7 +28,12 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 3.5" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python35,rh-python35"
+      io.openshift.tags="builder,python,python35,rh-python35" \
+      com.redhat.component="python35-docker" \
+      name="centos/python-35-centos7" \
+      version="3.5" \
+      release="1" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
 RUN yum install -y centos-release-scl-rh && \
     yum-config-manager --enable centos-sclo-rh-testing && \

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -26,14 +26,11 @@ LABEL summary="$SUMMARY" \
       io.k8s.description="$SUMMARY" \
       io.k8s.display-name="Python 3.5" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python35,rh-python35"
-
-# Labels consumed by Red Hat build service.
-LABEL com.redhat.component="rh-python35-docker" \
+      io.openshift.tags="builder,python,python35,rh-python35" \
+      com.redhat.component="rh-python35-docker" \
       name="rhscl/python-35-rhel7" \
       version="3.5" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 # To use subscription inside container yum command has to be run first (before yum-config-manager)
 # https://access.redhat.com/solutions/1443553


### PR DESCRIPTION
Provide same labels for all base image variants (CentOS, RHEL, Fedora)
 - follow recomended labels from Project Atomic Container best practices
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
 - use label 'maintainer' (MAINTAINER instruction is deprecated)
                                           
(don't use separate instruction for each label)

@hhorak @praiskup @pkubatrh Please take a look and merge.