### PR TITLE
Delete old unnecessary instructions in assemble

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -59,6 +59,3 @@ fi
 fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
-
-# remove pip temporary directory
-rm -rf /tmp/pip_build_default

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -63,6 +63,3 @@ fi
 fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
-
-# remove pip temporary directory
-rm -rf /tmp/pip_build_default

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -59,6 +59,3 @@ fi
 fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
-
-# remove pip temporary directory
-rm -rf /tmp/pip_build_default


### PR DESCRIPTION
The temporary build directory at this location is unused since this container
switched to using virtualenv. The new default build directory is at
`/opt/app-root/build/` and it's removed automatically by pip.

Resolves #182.