### PR TITLE
Prevent changing permissions on src twice

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -55,7 +55,5 @@ if should_collectstatic; then
   )
 fi
 
-# Fix source directory permissions
-fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root

--- a/3.3/s2i/bin/assemble
+++ b/3.3/s2i/bin/assemble
@@ -59,8 +59,6 @@ if should_collectstatic; then
   )
 fi
 
-# Fix source directory permissions
-fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root
 

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -59,7 +59,5 @@ if should_collectstatic; then
   )
 fi
 
-# Fix source directory permissions
-fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -55,7 +55,5 @@ if should_collectstatic; then
   )
 fi
 
-# Fix source directory permissions
-fix-permissions ./
 # set permissions for any installed artifacts
 fix-permissions /opt/app-root


### PR DESCRIPTION
The current working directory is always /opt/app-root/src when fix-permissions functions is called in assemble script. It is enough to call it once with the parent directory /opt/app-root as an argument.

Resolves issue #198.