### PR TITLE
Set owner and permissions on /opt/app-root correctly

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -50,16 +50,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable python27 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -52,16 +52,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable python27 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -50,16 +50,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python34 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -52,16 +52,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python34 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -51,16 +51,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python35 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -52,16 +52,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python35 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -50,16 +50,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python36 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001

--- a/3.6/Dockerfile.fedora
+++ b/3.6/Dockerfile.fedora
@@ -52,15 +52,15 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
-RUN virtualenv-$PYTHON_VERSION /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R og+rwx /opt/app-root
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
+RUN virtualenv-$PYTHON_VERSION /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root
 
 USER 1001
 

--- a/3.6/Dockerfile.rhel7
+++ b/3.6/Dockerfile.rhel7
@@ -51,16 +51,16 @@ COPY ./s2i/bin/ $STI_SCRIPTS_PATH
 # Copy extra files to the image.
 COPY ./root/ /
 
-# Create a Python virtual environment for use by any application to avoid
-# potential conflicts with Python packages preinstalled in the main Python
-# installation.
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
 RUN source scl_source enable rh-python36 && \
-    virtualenv /opt/app-root
-
-# In order to drop the root user, we have to make some directories world
-# writable as OpenShift default security model is to run the container under
-# random UID.
-RUN chown -R 1001:0 /opt/app-root && chmod -R ug+rwx /opt/app-root && \
+    virtualenv /opt/app-root && \
+    chown -R 1001:0 /opt/app-root && \
+    fix-permissions /opt/app-root && \
     rpm-file-permissions
 
 USER 1001


### PR DESCRIPTION
As discussed in issue #210 :
- the ownership and permissions should be set in the same instruction that
  /opt/app-root is created by, and
- fix-permissions is a more appropriate way to set the permissions.

I also added the rhel7.4 yum work-around.