### PR TITLE
Add support of pipenv packaging tool

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -105,6 +105,7 @@ a `.s2i/environment` file inside your source code repository.
 
     Set this variable to use a custom index URL or mirror to download required packages
     during build process. This only affects packages listed in requirements.txt.
+    Pipenv ignores this variable.
 
 * **UPGRADE_PIP_TO_LATEST**
 
@@ -112,6 +113,14 @@ a `.s2i/environment` file inside your source code repository.
     python packages (setuptools and wheel) be upgraded to the most recent version
     before any Python packages are installed. If not set it will use whatever
     the default version is included by the platform for the Python version being used.
+
+* **ENABLE_PIPENV**
+
+    Set this variable to use [Pipenv](https://github.com/kennethreitz/pipenv),
+    the higher-level Python packaging tool, to manage dependencies of the application.
+    This should be used only if your project contains properly formated Pipfile
+    and Pipfile.lock. (Implies `UPGRADE_PIP_TO_LATEST` to satisfy dependencies of
+    Pipenv.)
 
 * **WEB_CONCURRENCY**
 
@@ -131,14 +140,22 @@ However, if these files exist they will affect the behavior of the build process
   [here](https://pip.pypa.io/en/latest/user_guide.html#requirements-files).
 
 
+* **Pipfile**
+
+  The replacement for requirements.txt, project is currently under active
+  design and development, as documented [here](https://github.com/pypa/pipfile).
+  Set `ENABLE_PIPENV` environment variable to true in order to process this file.
+
+
 * **setup.py**
 
   Configures various aspects of the project, including installation of
   dependencies, as documented
   [here](https://packaging.python.org/en/latest/distributing.html#setup-py).
-  For most projects, it is sufficient to simply use `requirements.txt`, if this
-  file is present `setup.py` is not processed by default, please use `-e .` to
-  trigger its processing from the requirements.txt file.
+  For most projects, it is sufficient to simply use `requirements.txt` or
+  `Pipfile`, if one of these files is present `setup.py` is not processed
+  by default, please use `-e .` to trigger its processing from above mentioned
+  files.
 
 
 Run strategies

--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -8,18 +8,41 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+# Install pipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_pipenv() {
+  echo "---> Installing pipenv packaging tool ..."
+  VENV_DIR=$HOME/.local/venvs/pipenv
+  virtualenv $VENV_DIR
+  $VENV_DIR/bin/pip --isolated install -U pipenv
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+}
+
 set -e
 
 shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
   pip install -U pip setuptools wheel
 fi
 
-if [[ -f requirements.txt ]]; then
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
+  fi
+  pipenv check
+elif [[ -f requirements.txt ]]; then
   echo "---> Installing dependencies ..."
   pip install -r requirements.txt
 elif [[ -f setup.py ]]; then

--- a/2.7/test/pipenv-test-app/.gitignore
+++ b/2.7/test/pipenv-test-app/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/2.7/test/pipenv-test-app/.s2i/environment
+++ b/2.7/test/pipenv-test-app/.s2i/environment
@@ -1,0 +1,1 @@
+ENABLE_PIPENV=true

--- a/2.7/test/pipenv-test-app/Pipfile
+++ b/2.7/test/pipenv-test-app/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"e1839a8" = {path = ".", editable = true}
+requests = "==2.17.0"
+
+[dev-packages]
+pytest = ">=2.8.0"
+
+[requires]
+python_version = "2.7"

--- a/2.7/test/pipenv-test-app/Pipfile.lock
+++ b/2.7/test/pipenv-test-app/Pipfile.lock
@@ -1,0 +1,95 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "e1a2e7c9f2aab641899b7a3196572605b98ee2e1d2b62c24c9d066b34d186f14"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "0",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.5-200.fc26.x86_64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Thu Oct 5 16:53:13 UTC 2017",
+            "python_full_version": "2.7.13",
+            "python_version": "2.7",
+            "sys_platform": "linux2"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==2017.7.27.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "version": "==19.7.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
+                "sha256:3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"
+            ],
+            "version": "==2.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e",
+                "sha256:eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6"
+            ],
+            "version": "==2.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1",
+                "sha256:b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"
+            ],
+            "version": "==1.21.1"
+        }
+    },
+    "develop": {
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
+                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+            ],
+            "version": "==3.2.3"
+        }
+    }
+}

--- a/2.7/test/pipenv-test-app/setup.py
+++ b/2.7/test/pipenv-test-app/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+
+setup (
+    name             = "testapp",
+    version          = "0.1",
+    description      = "Example application to be deployed.",
+    packages         = find_packages(),
+    install_requires = ["gunicorn"],
+)

--- a/2.7/test/pipenv-test-app/testapp.py
+++ b/2.7/test/pipenv-test-app/testapp.py
@@ -1,0 +1,7 @@
+import requests
+
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    assert requests.__version__ == '2.17.0'
+    return [b"Hello from gunicorn WSGI application!"]

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-centos/python-27-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,setup-requirements,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
+declare -a WEB_APPS=({standalone,setup,setup-requirements,django,pipenv,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -105,6 +105,7 @@ file inside your source code repository.
 
     Set this variable to use a custom index URL or mirror to download required packages
     during build process. This only affects packages listed in requirements.txt.
+    Pipenv ignores this variable.
 
 * **UPGRADE_PIP_TO_LATEST**
 
@@ -112,6 +113,14 @@ file inside your source code repository.
     python packages (setuptools and wheel) be upgraded to the most recent version
     before any Python packages are installed. If not set it will use whatever
     the default version is included by the platform for the Python version being used.
+
+* **ENABLE_PIPENV**
+
+    Set this variable to use [Pipenv](https://github.com/kennethreitz/pipenv),
+    the higher-level Python packaging tool, to manage dependencies of the application.
+    This should be used only if your project contains properly formated Pipfile
+    and Pipfile.lock. (Implies `UPGRADE_PIP_TO_LATEST` to satisfy dependencies of
+    Pipenv.)
 
 * **WEB_CONCURRENCY**
 
@@ -131,14 +140,22 @@ However, if these files exist they will affect the behavior of the build process
   [here](https://pip.pypa.io/en/latest/user_guide.html#requirements-files).
 
 
+* **Pipfile**
+
+  The replacement for requirements.txt, project is currently under active
+  design and development, as documented [here](https://github.com/pypa/pipfile).
+  Set `ENABLE_PIPENV` environment variable to true in order to process this file.
+
+
 * **setup.py**
 
   Configures various aspects of the project, including installation of
   dependencies, as documented
   [here](https://packaging.python.org/en/latest/distributing.html#setup-py).
-  For most projects, it is sufficient to simply use `requirements.txt`, if this
-  file is present `setup.py` is not processed by default, please use `-e .` to
-  trigger its processing from the requirements.txt file.
+  For most projects, it is sufficient to simply use `requirements.txt` or
+  `Pipfile`, if one of these files is present `setup.py` is not processed
+  by default, please use `-e .` to trigger its processing from above mentioned
+  files.
 
 
 Run strategies

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -8,23 +8,43 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+# Install pipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_pipenv() {
+  echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
+  VENV_DIR=$HOME/.local/venvs/pipenv
+  virtualenv $VENV_DIR
+  $VENV_DIR/bin/pip --isolated install -U pipenv
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+}
+
 set -e
 
 shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
   pip install -U pip setuptools wheel
 fi
 
-if [[ -f requirements.txt ]]; then
-  if [ -n "$PIP_INDEX_URL" ]; then
-    echo "---> Installing dependencies via $PIP_INDEX_URL ..."
-  else
-    echo "---> Installing dependencies ..."
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
   fi
+  pipenv check
+elif [[ -f requirements.txt ]]; then
+  echo "---> Installing dependencies ..."
   pip install -r requirements.txt
 elif [[ -f setup.py ]]; then
   echo "---> Installing application ..."

--- a/3.4/test/pipenv-test-app/.gitignore
+++ b/3.4/test/pipenv-test-app/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/3.4/test/pipenv-test-app/.s2i/environment
+++ b/3.4/test/pipenv-test-app/.s2i/environment
@@ -1,0 +1,1 @@
+ENABLE_PIPENV=true

--- a/3.4/test/pipenv-test-app/Pipfile
+++ b/3.4/test/pipenv-test-app/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"e1839a8" = {path = ".", editable = true}
+requests = "==2.17.0"
+
+[dev-packages]
+pytest = ">=2.8.0"
+
+[requires]
+python_version = "3.4"

--- a/3.4/test/pipenv-test-app/Pipfile.lock
+++ b/3.4/test/pipenv-test-app/Pipfile.lock
@@ -1,0 +1,95 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "87826de2f3874f7c3828868c2a47d9315fced0f8a676ca489b7f657d7d41c7c4"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.4.5",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.5-200.fc26.x86_64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Thu Oct 5 16:53:13 UTC 2017",
+            "python_full_version": "3.4.5",
+            "python_version": "3.4",
+            "sys_platform": "linux"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.4"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==2017.7.27.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "version": "==19.7.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
+                "sha256:3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"
+            ],
+            "version": "==2.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e",
+                "sha256:eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6"
+            ],
+            "version": "==2.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1",
+                "sha256:b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"
+            ],
+            "version": "==1.21.1"
+        }
+    },
+    "develop": {
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
+                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+            ],
+            "version": "==3.2.3"
+        }
+    }
+}

--- a/3.4/test/pipenv-test-app/setup.py
+++ b/3.4/test/pipenv-test-app/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+
+setup (
+    name             = "testapp",
+    version          = "0.1",
+    description      = "Example application to be deployed.",
+    packages         = find_packages(),
+    install_requires = ["gunicorn"],
+)

--- a/3.4/test/pipenv-test-app/testapp.py
+++ b/3.4/test/pipenv-test-app/testapp.py
@@ -1,0 +1,7 @@
+import requests
+
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    assert requests.__version__ == '2.17.0'
+    return [b"Hello from gunicorn WSGI application!"]

--- a/3.4/test/run
+++ b/3.4/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-centos/python-34-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,setup-requirements,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
+declare -a WEB_APPS=({standalone,setup,setup-requirements,pipenv,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -105,6 +105,7 @@ file inside your source code repository.
 
     Set this variable to use a custom index URL or mirror to download required packages
     during build process. This only affects packages listed in requirements.txt.
+    Pipenv ignores this variable.
 
 * **UPGRADE_PIP_TO_LATEST**
 
@@ -112,6 +113,14 @@ file inside your source code repository.
     python packages (setuptools and wheel) be upgraded to the most recent version
     before any Python packages are installed. If not set it will use whatever
     the default version is included by the platform for the Python version being used.
+
+* **ENABLE_PIPENV**
+
+    Set this variable to use [Pipenv](https://github.com/kennethreitz/pipenv),
+    the higher-level Python packaging tool, to manage dependencies of the application.
+    This should be used only if your project contains properly formated Pipfile
+    and Pipfile.lock. (Implies `UPGRADE_PIP_TO_LATEST` to satisfy dependencies of
+    Pipenv.)
 
 * **WEB_CONCURRENCY**
 
@@ -131,14 +140,22 @@ However, if these files exist they will affect the behavior of the build process
   [here](https://pip.pypa.io/en/latest/user_guide.html#requirements-files).
 
 
+* **Pipfile**
+
+  The replacement for requirements.txt, project is currently under active
+  design and development, as documented [here](https://github.com/pypa/pipfile).
+  Set `ENABLE_PIPENV` environment variable to true in order to process this file.
+
+
 * **setup.py**
 
   Configures various aspects of the project, including installation of
   dependencies, as documented
   [here](https://packaging.python.org/en/latest/distributing.html#setup-py).
-  For most projects, it is sufficient to simply use `requirements.txt`, if this
-  file is present `setup.py` is not processed by default, please use `-e .` to
-  trigger its processing from the requirements.txt file.
+  For most projects, it is sufficient to simply use `requirements.txt` or
+  `Pipfile`, if one of these files is present `setup.py` is not processed
+  by default, please use `-e .` to trigger its processing from above mentioned
+  files.
 
 
 Run strategies

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -8,18 +8,41 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+# Install pipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_pipenv() {
+  echo "---> Installing pipenv packaging tool ..."
+  VENV_DIR=$HOME/.local/venvs/pipenv
+  virtualenv $VENV_DIR
+  $VENV_DIR/bin/pip --isolated install -U pipenv
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+}
+
 set -e
 
 shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
   pip install -U pip setuptools wheel
 fi
 
-if [[ -f requirements.txt ]]; then
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
+  fi
+  pipenv check
+elif [[ -f requirements.txt ]]; then
   echo "---> Installing dependencies ..."
   pip install -r requirements.txt
 elif [[ -f setup.py ]]; then

--- a/3.5/test/pipenv-test-app/.gitignore
+++ b/3.5/test/pipenv-test-app/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/3.5/test/pipenv-test-app/.s2i/environment
+++ b/3.5/test/pipenv-test-app/.s2i/environment
@@ -1,0 +1,1 @@
+ENABLE_PIPENV=true

--- a/3.5/test/pipenv-test-app/Pipfile
+++ b/3.5/test/pipenv-test-app/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"e1839a8" = {path = ".", editable = true}
+requests = "==2.17.0"
+
+[dev-packages]
+pytest = ">=2.8.0"
+
+[requires]
+python_version = "3.5"

--- a/3.5/test/pipenv-test-app/Pipfile.lock
+++ b/3.5/test/pipenv-test-app/Pipfile.lock
@@ -1,0 +1,95 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "f1246f5a691fc5fca955313011d3ac03013a39512b3d5df949a3d7f41892f0de"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.5.3",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.5-200.fc26.x86_64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Thu Oct 5 16:53:13 UTC 2017",
+            "python_full_version": "3.5.3",
+            "python_version": "3.5",
+            "sys_platform": "linux"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.5"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==2017.7.27.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "version": "==19.7.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
+                "sha256:3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"
+            ],
+            "version": "==2.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e",
+                "sha256:eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6"
+            ],
+            "version": "==2.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1",
+                "sha256:b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"
+            ],
+            "version": "==1.21.1"
+        }
+    },
+    "develop": {
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
+                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+            ],
+            "version": "==3.2.3"
+        }
+    }
+}

--- a/3.5/test/pipenv-test-app/setup.py
+++ b/3.5/test/pipenv-test-app/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+
+setup (
+    name             = "testapp",
+    version          = "0.1",
+    description      = "Example application to be deployed.",
+    packages         = find_packages(),
+    install_requires = ["gunicorn"],
+)

--- a/3.5/test/pipenv-test-app/testapp.py
+++ b/3.5/test/pipenv-test-app/testapp.py
@@ -1,0 +1,7 @@
+import requests
+
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    assert requests.__version__ == '2.17.0'
+    return [b"Hello from gunicorn WSGI application!"]

--- a/3.5/test/run
+++ b/3.5/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-sclorg/python-35-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,setup-requirements,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
+declare -a WEB_APPS=({standalone,setup,setup-requirements,pipenv,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -105,6 +105,7 @@ file inside your source code repository.
 
     Set this variable to use a custom index URL or mirror to download required packages
     during build process. This only affects packages listed in requirements.txt.
+    Pipenv ignores this variable.
 
 * **UPGRADE_PIP_TO_LATEST**
 
@@ -112,6 +113,13 @@ file inside your source code repository.
     python packages (setuptools and wheel) be upgraded to the most recent version
     before any Python packages are installed. If not set it will use whatever
     the default version is included by the platform for the Python version being used.
+
+* **ENABLE_PIPENV**
+
+    Set this variable to use [Pipenv](https://github.com/kennethreitz/pipenv),
+    the higher-level Python packaging tool, to manage dependencies of the application.
+    This should be used only if your project contains properly formated Pipfile
+    and Pipfile.lock.
 
 * **WEB_CONCURRENCY**
 
@@ -131,14 +139,22 @@ However, if these files exist they will affect the behavior of the build process
   [here](https://pip.pypa.io/en/latest/user_guide.html#requirements-files).
 
 
+* **Pipfile**
+
+  The replacement for requirements.txt, project is currently under active
+  design and development, as documented [here](https://github.com/pypa/pipfile).
+  Set `ENABLE_PIPENV` environment variable to true in order to process this file.
+
+
 * **setup.py**
 
   Configures various aspects of the project, including installation of
   dependencies, as documented
   [here](https://packaging.python.org/en/latest/distributing.html#setup-py).
-  For most projects, it is sufficient to simply use `requirements.txt`, if this
-  file is present `setup.py` is not processed by default, please use `-e .` to
-  trigger its processing from the requirements.txt file.
+  For most projects, it is sufficient to simply use `requirements.txt` or
+  `Pipfile`, if one of these files is present `setup.py` is not processed
+  by default, please use `-e .` to trigger its processing from above mentioned
+  files.
 
 
 Run strategies

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -8,6 +8,20 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+# Install pipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_pipenv() {
+  echo "---> Installing pipenv packaging tool ..."
+  VENV_DIR=$HOME/.local/venvs/pipenv
+  virtualenv $VENV_DIR
+  $VENV_DIR/bin/pip --isolated install -U pipenv
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv
+}
+
 set -e
 
 shopt -s dotglob
@@ -19,7 +33,16 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
   pip install -U pip setuptools wheel
 fi
 
-if [[ -f requirements.txt ]]; then
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
+  fi
+  pipenv check
+elif [[ -f requirements.txt ]]; then
   echo "---> Installing dependencies ..."
   pip install -r requirements.txt
 elif [[ -f setup.py ]]; then

--- a/3.6/test/pipenv-test-app/.gitignore
+++ b/3.6/test/pipenv-test-app/.gitignore
@@ -1,0 +1,57 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/3.6/test/pipenv-test-app/.s2i/environment
+++ b/3.6/test/pipenv-test-app/.s2i/environment
@@ -1,0 +1,1 @@
+ENABLE_PIPENV=true

--- a/3.6/test/pipenv-test-app/Pipfile
+++ b/3.6/test/pipenv-test-app/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+"e1839a8" = {path = ".", editable = true}
+requests = "==2.17.0"
+
+[dev-packages]
+pytest = ">=2.8.0"
+
+[requires]
+python_version = "3.6"

--- a/3.6/test/pipenv-test-app/Pipfile.lock
+++ b/3.6/test/pipenv-test-app/Pipfile.lock
@@ -1,0 +1,95 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "96a91e22aeebfddebc44a2cbc2c5db51b4040ca72b3cbff2af387ad2603cd5c5"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.6.2",
+            "os_name": "posix",
+            "platform_machine": "x86_64",
+            "platform_python_implementation": "CPython",
+            "platform_release": "4.13.5-200.fc26.x86_64",
+            "platform_system": "Linux",
+            "platform_version": "#1 SMP Thu Oct 5 16:53:13 UTC 2017",
+            "python_full_version": "3.6.2",
+            "python_version": "3.6",
+            "sys_platform": "linux"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:54a07c09c586b0e4c619f02a5e94e36619da8e2b053e20f594348c0611803704",
+                "sha256:40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+            ],
+            "version": "==2017.7.27.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691",
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+            ],
+            "version": "==3.0.4"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
+                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+            ],
+            "version": "==19.7.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:cc19709fd6d0cbfed39ea875d29ba6d4e22c0cebc510a76d6302a28385e8bb70",
+                "sha256:3cb5ce08046c4e3a560fc02f138d0ac63e00f8ce5901a56b32ec8b7994082aab"
+            ],
+            "version": "==2.5"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:73b4088c05f7fb5ca8e68651ed802df3ca40621281acf74bb321b4a8408aab7e",
+                "sha256:eff227db5864238d44270cbadc8ac4133e69b69a2e7092b7b316ed1e4761cbd6"
+            ],
+            "version": "==2.17.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8ed6d5c1ff9d6ba84677310060d6a3a78ca3072ce0684cb3c645023009c114b1",
+                "sha256:b14486978518ca0901a76ba973d7821047409d7f726f22156b24e83fd71382a5"
+            ],
+            "version": "==1.21.1"
+        }
+    },
+    "develop": {
+        "py": {
+            "hashes": [
+                "sha256:2ccb79b01769d99115aa600d7eed99f524bf752bba8f041dc1c184853514655a",
+                "sha256:0f2d585d22050e90c7d293b6451c83db097df77871974d90efd5a30dc12fcde3"
+            ],
+            "version": "==1.4.34"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:81a25f36a97da3313e1125fce9e7bbbba565bc7fec3c5beb14c262ddab238ac1",
+                "sha256:27fa6617efc2869d3e969a3e75ec060375bfb28831ade8b5cdd68da3a741dc3c"
+            ],
+            "version": "==3.2.3"
+        }
+    }
+}

--- a/3.6/test/pipenv-test-app/setup.py
+++ b/3.6/test/pipenv-test-app/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+
+setup (
+    name             = "testapp",
+    version          = "0.1",
+    description      = "Example application to be deployed.",
+    packages         = find_packages(),
+    install_requires = ["gunicorn"],
+)

--- a/3.6/test/pipenv-test-app/testapp.py
+++ b/3.6/test/pipenv-test-app/testapp.py
@@ -1,0 +1,7 @@
+import requests
+
+
+def application(environ, start_response):
+    start_response('200 OK', [('Content-Type', 'text/plain')])
+    assert requests.__version__ == '2.17.0'
+    return [b"Hello from gunicorn WSGI application!"]

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -8,7 +8,7 @@
 #
 IMAGE_NAME=${IMAGE_NAME:-sclorg/python-36-centos7-candidate}
 
-declare -a WEB_APPS=({standalone,setup,setup-requirements,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
+declare -a WEB_APPS=({standalone,setup,setup-requirements,pipenv,django,numpy,app-home,npm-virtualenv-uwsgi,locale,mod-wsgi}-test-app)
 
 # TODO: Make command compatible for Mac users
 test_dir="$(readlink -zf $(dirname "${BASH_SOURCE[0]}"))"


### PR DESCRIPTION
Pipenv, the higher-level Python packaging tool can be used to manage application dependencies 
if user requests it by setting ENABLE_PIPENV environment variable to true. Pipenv and its dependecies
are sandboxed so they cannot conflict with neither system packages nor application dependencies.
This PR contains:
- support of pipenv in assemble script
- simple test application using Pipfile
- update of relevant parts of documentation
