### PR TITLE
Limit number of gunicorn workers to 12 at maximum. Fixes #199

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -117,7 +117,8 @@ a `.s2i/environment` file inside your source code repository.
 
     Set this to change the default setting for the number of
     [workers](http://docs.gunicorn.org/en/stable/settings.html#workers). By
-    default, this is set to the number of available cores times 4.
+    default, this is set to the number of available cores times 2, capped
+    at 12.
 
 Source repository layout
 ------------------------

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -29,6 +29,9 @@ function get_default_web_concurrency() {
   local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
   echo $default
 }
 

--- a/3.4/README.md
+++ b/3.4/README.md
@@ -117,7 +117,8 @@ file inside your source code repository.
 
     Set this to change the default setting for the number of
     [workers](http://docs.gunicorn.org/en/stable/settings.html#workers). By
-    default, this is set to the number of available cores times 2.
+    default, this is set to the number of available cores times 2, capped
+    at 12.
 
 Source repository layout
 ------------------------

--- a/3.4/s2i/bin/run
+++ b/3.4/s2i/bin/run
@@ -29,6 +29,9 @@ function get_default_web_concurrency() {
   local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
   echo $default
 }
 

--- a/3.5/README.md
+++ b/3.5/README.md
@@ -117,7 +117,8 @@ file inside your source code repository.
 
     Set this to change the default setting for the number of
     [workers](http://docs.gunicorn.org/en/stable/settings.html#workers). By
-    default, this is set to the number of available cores times 2.
+    default, this is set to the number of available cores times 2, capped
+    at 12.
 
 Source repository layout
 ------------------------

--- a/3.5/s2i/bin/run
+++ b/3.5/s2i/bin/run
@@ -29,6 +29,9 @@ function get_default_web_concurrency() {
   local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
   echo $default
 }
 

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -117,7 +117,8 @@ file inside your source code repository.
 
     Set this to change the default setting for the number of
     [workers](http://docs.gunicorn.org/en/stable/settings.html#workers). By
-    default, this is set to the number of available cores times 2.
+    default, this is set to the number of available cores times 2, capped
+    at 12.
 
 Source repository layout
 ------------------------

--- a/3.6/s2i/bin/run
+++ b/3.6/s2i/bin/run
@@ -29,6 +29,9 @@ function get_default_web_concurrency() {
   local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
   echo $default
 }
 


### PR DESCRIPTION
As I understand it, the `3.3` image is not maintained any more, so I didn't fix values for it.