### PR TITLE
Replace removed s2i flag in tests

### DIFF
--- a/2.7/test/run
+++ b/2.7/test/run
@@ -187,7 +187,7 @@ test_application() {
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage

--- a/3.4/test/run
+++ b/3.4/test/run
@@ -172,7 +172,7 @@ test_application() {
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage

--- a/3.5/test/run
+++ b/3.5/test/run
@@ -172,7 +172,7 @@ test_application() {
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -172,7 +172,7 @@ test_application() {
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
-s2i_args="--force-pull=false"
+s2i_args="--pull-policy=never"
 
 # Verify the 'usage' script is working properly when running the base image with 's2i usage ...'
 test_s2i_usage


### PR DESCRIPTION
The deprecated --force-pull flag [was removed](https://github.com/openshift/source-to-image/commit/2816855ca0e3a0899a1124e387ac28424c32502e) in source-to-image [v1.1.6](https://github.com/openshift/source-to-image/releases/tag/v1.1.6) 
`--pull-policy=never` can be used instead.