### PR TITLE
Add .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+# The main project repository https://github.com/sclorg/s2i-python-container.git
+# uses CentOS-CI, Travis is not enabled at this moment.
+# The purpose of this file is to add possibility of an alternative CI service
+# in repository forks.
+
+sudo: required
+
+services: 
+  - docker
+
+language: go
+
+go: 1.6
+
+before_install: 
+  - sudo apt-get install -y go-md2man
+
+install: 
+  - go get github.com/openshift/source-to-image
+  - pushd ${GOPATH}/src/github.com/openshift/source-to-image
+  - export PATH=$PATH:${GOPATH}/src/github.com/openshift/source-to-image/_output/local/bin/linux/amd64/
+  - hack/build-go.sh
+  - popd
+
+script: SKIP_SQUASH=1 make test TARGET=centos


### PR DESCRIPTION
I set up Travis CI builds to run test suit for CentOS images after each commit in my fork. I think It would be nice to have .travis.yml file in the sources, even in case Travis won't be enabled for this repository. Some other contributors might find the possibility of alternative CI service helpful.