### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ services:
 
 language: go
 
-go: 1.6
+go: latest
 
 before_install: 
+  - sudo apt-get update -qq
   - sudo apt-get install -y go-md2man
 
 install: 


### PR DESCRIPTION
source-to-image cannot be build with Go 1.6 after [the latest update of Godeps](https://github.com/openshift/source-to-image/commit/c2be0ab3991d90d87f9f0e6f318e7cf03276c0d1). Travis file has to be updated.