### PR TITLE
Use -P option of find command in fix-permissions script

### DIFF
--- a/2.7/Dockerfile
+++ b/2.7/Dockerfile
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable python27 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/2.7/Dockerfile.rhel7
+++ b/2.7/Dockerfile.rhel7
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable python27 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.4/Dockerfile
+++ b/3.4/Dockerfile
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python34 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.4/Dockerfile.rhel7
+++ b/3.4/Dockerfile.rhel7
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python34 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.5/Dockerfile
+++ b/3.5/Dockerfile
@@ -60,7 +60,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python35 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.5/Dockerfile.rhel7
+++ b/3.5/Dockerfile.rhel7
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python35 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -60,7 +60,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python36 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001

--- a/3.6/Dockerfile.fedora
+++ b/3.6/Dockerfile.fedora
@@ -61,7 +61,7 @@ COPY ./root/ /
 #   under random UID.
 RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT}
+    fix-permissions ${APP_ROOT} -P
 
 USER 1001
 

--- a/3.6/Dockerfile.rhel7
+++ b/3.6/Dockerfile.rhel7
@@ -59,7 +59,7 @@ COPY ./root/ /
 RUN source scl_source enable rh-python36 && \
     virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
-    fix-permissions ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions
 
 USER 1001


### PR DESCRIPTION
Stop following symlinks when running fix-permissions script under root to prevent undesirable permission changes of software collection files. Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1536129.