### PR TITLE
 Bring s2i scripts in line between versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.image-id
+.image-id.raw
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -15,6 +15,7 @@ function should_collectstatic() {
 # (pip script installer).
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
   virtualenv $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv

--- a/2.7/s2i/bin/run
+++ b/2.7/s2i/bin/run
@@ -25,8 +25,8 @@ function get_default_web_concurrency() {
   fi
 
   local max=$((NUMBER_OF_CORES*2))
-  # Require at least 40 MiB and additional 40 MiB for every worker
-  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 40) / 40))
+  # Require at least 43 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
   default=$((default > max ? max : default))
   default=$((default < 1 ? 1 : default))
   # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -15,6 +15,7 @@ function should_collectstatic() {
 # (pip script installer).
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
   virtualenv $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -15,6 +15,7 @@ function should_collectstatic() {
 # (pip script installer).
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
   virtualenv $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv
@@ -28,7 +29,7 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
   pip install -U pip setuptools wheel
 fi

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,8 @@ OPENSHIFT_NAMESPACES = 3.3
 .PHONY: $(shell test -f common/common.mk || echo >&2 'Please do "git submodule update --init" first.')
 
 include common/common.mk
+
+sync:
+	cp 3.6/s2i/bin/{assemble,run} 3.5/s2i/bin/
+	cp 3.6/s2i/bin/{assemble,run} 3.4/s2i/bin/
+	cp 3.6/s2i/bin/{assemble,run} 2.7/s2i/bin/


### PR DESCRIPTION
It's hard to introduce changes to the s2i scripts due to differences between the individual versions. This change aims to reduce the differences and increase maintainability.

- add `make sync` to copy `s2i/bin/{run,assemble}` from 3.6 to the other versions. Can of course be improved to copy mor files and be more flexible
- update `s2i/bin/{run,assemble}` to be identical for all supported versions

On long term it may make sense to have some kind of "template", similar to other repositories and helper scripts to generate the files for each version.