### PR TITLE
Make sure Pipenv is installed into updated virtualenv on 2.7 and 3.5

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -15,6 +15,7 @@ function should_collectstatic() {
 # (pip script installer).
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
   virtualenv $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -15,6 +15,7 @@ function should_collectstatic() {
 # (pip script installer).
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
+  pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
   virtualenv $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv


### PR DESCRIPTION
[The latest release of Pipenv](https://github.com/pypa/pipenv/releases/tag/v11.9.0)  uses advanced syntax to define install requiremets in setup.py script. Pip version bundled inside virtualenv present in rh-python35 and python27 collections is too old to handle this syntax, which causes CI failures. Virtualenv has to be updated to the latest version in order to install Pipenv successfully.  