### PR TITLE
Fedora tests fix

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -8,6 +8,14 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+function virtualenv_bin() {
+  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+    virtualenv-${PYTHON_VERSION} $1
+  else
+    virtualenv $1
+  fi
+}
+
 # Install pipenv to the separate virtualenv to isolate it
 # from system Python packages and packages in the main
 # virtualenv. Executable is simlinked into ~/.local/bin
@@ -17,7 +25,7 @@ function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
   pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
-  virtualenv $VENV_DIR
+  virtualenv_bin "$VENV_DIR"
   $VENV_DIR/bin/pip --isolated install -U pipenv
   mkdir -p $HOME/.local/bin
   ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv

--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -9,7 +9,7 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+  if head "/etc/redhat-release" | grep -q "^Fedora"; then
     virtualenv-${PYTHON_VERSION} $1
   else
     virtualenv $1

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -8,6 +8,14 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+function virtualenv_bin() {
+  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+    virtualenv-${PYTHON_VERSION} $1
+  else
+    virtualenv $1
+  fi
+}
+
 # Install pipenv to the separate virtualenv to isolate it
 # from system Python packages and packages in the main
 # virtualenv. Executable is simlinked into ~/.local/bin
@@ -17,7 +25,7 @@ function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
   pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
-  virtualenv $VENV_DIR
+  virtualenv_bin $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv
   mkdir -p $HOME/.local/bin
   ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv

--- a/3.4/s2i/bin/assemble
+++ b/3.4/s2i/bin/assemble
@@ -9,7 +9,7 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+  if head "/etc/redhat-release" | grep -q "^Fedora"; then
     virtualenv-${PYTHON_VERSION} $1
   else
     virtualenv $1

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -8,6 +8,14 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+function virtualenv_bin() {
+  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+    virtualenv-${PYTHON_VERSION} $1
+  else
+    virtualenv $1
+  fi
+}
+
 # Install pipenv to the separate virtualenv to isolate it
 # from system Python packages and packages in the main
 # virtualenv. Executable is simlinked into ~/.local/bin
@@ -17,7 +25,7 @@ function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
   pip install -U virtualenv
   VENV_DIR=$HOME/.local/venvs/pipenv
-  virtualenv $VENV_DIR
+  virtualenv_bin $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv
   mkdir -p $HOME/.local/bin
   ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv

--- a/3.5/s2i/bin/assemble
+++ b/3.5/s2i/bin/assemble
@@ -9,7 +9,7 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+  if head "/etc/redhat-release" | grep -q "^Fedora"; then
     virtualenv-${PYTHON_VERSION} $1
   else
     virtualenv $1

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -8,6 +8,14 @@ function should_collectstatic() {
   is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
 }
 
+function virtualenv_bin() {
+  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+    virtualenv-${PYTHON_VERSION} $1
+  else
+    virtualenv $1
+  fi
+}
+
 # Install pipenv to the separate virtualenv to isolate it
 # from system Python packages and packages in the main
 # virtualenv. Executable is simlinked into ~/.local/bin
@@ -16,7 +24,7 @@ function should_collectstatic() {
 function install_pipenv() {
   echo "---> Installing pipenv packaging tool ..."
   VENV_DIR=$HOME/.local/venvs/pipenv
-  virtualenv $VENV_DIR
+  virtualenv_bin $VENV_DIR
   $VENV_DIR/bin/pip --isolated install -U pipenv
   mkdir -p $HOME/.local/bin
   ln -s $VENV_DIR/bin/pipenv $HOME/.local/bin/pipenv

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -9,7 +9,7 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if [[ $(head /etc/redhat-release) =~ ^Fedora.* ]]; then
+  if head "/etc/redhat-release" | grep -q "^Fedora"; then
     virtualenv-${PYTHON_VERSION} $1
   else
     virtualenv $1

--- a/test/run
+++ b/test/run
@@ -165,9 +165,9 @@ test_application() {
 
   test_scl_usage "python --version" "Python $VERSION." "${cid_file}"
   check_result $?
-  test_scl_usage "node --version" "^v6." "${cid_file}"
+  test_scl_usage "node --version" "^v[0-9]*\.[0-9]*\.[0-9]*" "${cid_file}"
   check_result $?
-  test_scl_usage "npm --version" "^3." "${cid_file}"
+  test_scl_usage "npm --version" "^[0-9]*\.[0-9]*\.[0-9]*" "${cid_file}"
   check_result $?
   test_connection
   check_result $?


### PR DESCRIPTION
This PR intend to resolve #263, #264 and #265. As far as node and npm can be updated quite often on Fedora I don't think we can use something less general then the version number [regex in test_scl_usage](https://github.com/sclorg/s2i-python-container/commit/21514a1741d7f12119edbf738690cb84675f4619#diff-a6e781883513014286df21a2e0e8aaa2L168)