### PR TITLE
add imagestream and examples for python 2.7 and 3.6 on ppc64le

### DIFF
--- a/imagestreams/python-rhel7-ppc64le.json
+++ b/imagestreams/python-rhel7-ppc64le.json
@@ -1,0 +1,73 @@
+{
+  "kind": "ImageStream",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "python",
+    "annotations": {
+      "openshift.io/display-name": "Python"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Python (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major versions updates.",
+          "iconClass": "icon-python",
+          "tags": "builder,python,ppc64le",
+          "supports":"python",
+          "sampleRepo": "https://github.com/openshift/django-ex.git"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "3.6"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "2.7",
+        "annotations": {
+          "openshift.io/display-name": "Python 2.7",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python 2.7 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
+          "iconClass": "icon-python",
+          "tags": "builder,python",
+          "supports":"python:2.7,python,ppc64le",
+          "version": "2.7",
+          "sampleRepo": "https://github.com/openshift/django-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/python-27-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.6",
+        "annotations": {
+          "openshift.io/display-name": "Python 3.6",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python 3.6 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.",
+          "iconClass": "icon-python",
+          "tags": "builder,python,ppc64le",
+          "supports":"python:3.6,python",
+          "version": "3.6",
+          "sampleRepo": "https://github.com/openshift/django-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhscl/python-36-rhel7:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
add imagestream and examples for python 2.7 and 3.6 on ppc64le