### PR TITLE
Update common submodule and fix tests

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -27,6 +27,6 @@ ct_os_test_template_app "${IMAGE_NAME}" \
                         https://raw.githubusercontent.com/hhorak/django-ex/python-3.6/openshift/templates/django-postgresql.json \
                         python \
                         'Welcome to your Django application on OpenShift' \
-                        8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6" \
+                        8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
                         "centos/postgresql-96-centos7|postgresql:9.6"
 


### PR DESCRIPTION
It is necessary to define `NAME` variable, so we don't need to guess names of the services.