### PR TITLE
OKD rebranding and sclorg move for s2i-python-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Users can choose between RHEL, Fedora and CentOS based builder images.
 The resulting image can be run using [Docker](http://docker.io).
 
 For more information about using these images with OpenShift, please see the
-official [OpenShift Documentation](https://docs.openshift.org/latest/using_images/s2i_images/python.html).
+official [OpenShift Documentation](https://docs.okd.io/latest/using_images/s2i_images/python.html).
 
 For more information about concepts used in these container images, see the
 [Landing page](https://github.com/sclorg/welcome).

--- a/examples/django-postgresql-persistent.json
+++ b/examples/django-postgresql-persistent.json
@@ -5,16 +5,16 @@
     "name": "django-psql-persistent",
     "annotations": {
       "openshift.io/display-name": "Django + PostgreSQL (Persistent)",
-      "description": "An example Django application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/django-ex/blob/master/README.md.",
+      "description": "An example Django application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/django-ex/blob/master/README.md.",
       "tags": "quickstart,python,django",
       "iconClass": "icon-python",
       "template.openshift.io/long-description": "This template defines resources needed to develop a Django based application, including a build configuration, application deployment configuration, and database deployment configuration.",
       "template.openshift.io/provider-display-name": "Red Hat, Inc.",
-      "template.openshift.io/documentation-url": "https://github.com/openshift/django-ex",
+      "template.openshift.io/documentation-url": "https://github.com/sclorg/django-ex",
       "template.openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/openshift/django-ex/blob/master/README.md.",
+  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/django-ex/blob/master/README.md.",
   "labels": {
     "template": "django-psql-persistent"
   },
@@ -464,7 +464,7 @@
       "displayName": "Git Repository URL",
       "required": true,
       "description": "The URL of the repository with your application source code.",
-      "value": "https://github.com/openshift/django-ex.git"
+      "value": "https://github.com/sclorg/django-ex.git"
     },
     {
       "name": "SOURCE_REPOSITORY_REF",

--- a/examples/django-postgresql.json
+++ b/examples/django-postgresql.json
@@ -5,16 +5,16 @@
     "name": "django-psql-example",
     "annotations": {
       "openshift.io/display-name": "Django + PostgreSQL (Ephemeral)",
-      "description": "An example Django application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/openshift/django-ex/blob/master/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
+      "description": "An example Django application with a PostgreSQL database. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/django-ex/blob/master/README.md.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing.",
       "tags": "quickstart,python,django",
       "iconClass": "icon-python",
       "template.openshift.io/long-description": "This template defines resources needed to develop a Django based application, including a build configuration, application deployment configuration, and database deployment configuration.  The database is stored in non-persistent storage, so this configuration should be used for experimental purposes only.",
       "template.openshift.io/provider-display-name": "Red Hat, Inc.",
-      "template.openshift.io/documentation-url": "https://github.com/openshift/django-ex",
+      "template.openshift.io/documentation-url": "https://github.com/sclorg/django-ex",
       "template.openshift.io/support-url": "https://access.redhat.com"
     }
   },
-  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/openshift/django-ex/blob/master/README.md.",
+  "message": "The following service(s) have been created in your project: ${NAME}, ${DATABASE_SERVICE_NAME}.\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/django-ex/blob/master/README.md.",
   "labels": {
     "template": "django-psql-example"
   },
@@ -438,7 +438,7 @@
       "displayName": "Git Repository URL",
       "required": true,
       "description": "The URL of the repository with your application source code.",
-      "value": "https://github.com/openshift/django-ex.git"
+      "value": "https://github.com/sclorg/django-ex.git"
     },
     {
       "name": "SOURCE_REPOSITORY_REF",

--- a/imagestreams/python-centos7.json
+++ b/imagestreams/python-centos7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-python",
           "tags": "builder,python",
           "supports":"python",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,python",
           "supports":"python:3.3,python",
           "version": "3.3",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "builder,python",
           "supports":"python:2.7,python",
           "version": "2.7",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "hidden,builder,python",
           "supports":"python:3.4,python",
           "version": "3.4",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,python",
           "supports":"python:3.5,python",
           "version": "3.5",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -118,7 +118,7 @@
           "tags": "builder,python",
           "supports":"python:3.6,python",
           "version": "3.6",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/python-rhel7-ppc64le.json
+++ b/imagestreams/python-rhel7-ppc64le.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-python",
           "tags": "builder,python,ppc64le",
           "supports":"python",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "builder,python",
           "supports":"python:2.7,python,ppc64le",
           "version": "2.7",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "builder,python,ppc64le",
           "supports":"python:3.6,python",
           "version": "3.6",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/imagestreams/python-rhel7.json
+++ b/imagestreams/python-rhel7.json
@@ -18,7 +18,7 @@
           "iconClass": "icon-python",
           "tags": "builder,python",
           "supports":"python",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "ImageStreamTag",
@@ -38,7 +38,7 @@
           "tags": "hidden,builder,python",
           "supports":"python:3.3,python",
           "version": "3.3",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -58,7 +58,7 @@
           "tags": "builder,python",
           "supports":"python:2.7,python",
           "version": "2.7",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -78,7 +78,7 @@
           "tags": "hidden,builder,python",
           "supports":"python:3.4,python",
           "version": "3.4",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -98,7 +98,7 @@
           "tags": "builder,python",
           "supports":"python:3.5,python",
           "version": "3.5",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",
@@ -118,7 +118,7 @@
           "tags": "builder,python",
           "supports":"python:3.6,python",
           "version": "3.6",
-          "sampleRepo": "https://github.com/openshift/django-ex.git"
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
         },
         "from": {
           "kind": "DockerImage",

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -20,9 +20,9 @@ ct_os_cluster_up
 
 ct_os_test_s2i_app "${IMAGE_NAME}" "${THISDIR}/standalone-test-app" . "Hello World from standalone WSGI application!"
 
-ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/openshift/django-ex.git" . 'Welcome to your Django application on OpenShift'
+ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
 
-# TODO: update the template reference to proper location, once https://github.com/openshift/django-ex/pull/115 is merged
+# TODO: update the template reference to proper location, once https://github.com/sclorg/django-ex/pull/115 is merged
 ct_os_test_template_app "${IMAGE_NAME}" \
                         https://raw.githubusercontent.com/hhorak/django-ex/python-3.6/openshift/templates/django-postgresql.json \
                         python \


### PR DESCRIPTION
docs.openshift.org to docs.okd.io
github.com/openshift/django-ex to github.com/sclorg/django-ex