### PR TITLE
using Fedora 28 image as a base

### DIFF
--- a/3.6/Dockerfile.fedora
+++ b/3.6/Dockerfile.fedora
@@ -1,6 +1,6 @@
 # This image provides a Python 3.6 environment you can use to run your Python
 # applications.
-FROM registry.fedoraproject.org/f27/s2i-base:latest
+FROM registry.fedoraproject.org/f28/s2i-base:latest
 
 EXPOSE 8080
 


### PR DESCRIPTION
This is changing only Python 3.6