### PR TITLE
Activate virtualenv in Fedora image

### DIFF
--- a/3.6/Dockerfile.fedora
+++ b/3.6/Dockerfile.fedora
@@ -36,7 +36,6 @@ LABEL summary="$SUMMARY" \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ $FGC/$NAME python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
@@ -62,6 +61,12 @@ COPY ./root/ /
 RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P
+
+# For Fedora scl_enable isn't sourced automatically in s2i-core
+# so virtualenv needs to be activated this way
+ENV BASH_ENV="${APP_ROOT}/bin/activate" \
+    ENV="${APP_ROOT}/bin/activate" \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -37,8 +37,8 @@ specs:
 
     fedora:
       distros:
-        - fedora-27-x86_64
-      s2i_base: registry.fedoraproject.org/f27/s2i-base
+        - fedora-28-x86_64
+      s2i_base: registry.fedoraproject.org/f28/s2i-base
       img_tag: "latest"
       python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip',
                     'python3-virtualenv']
@@ -66,8 +66,8 @@ specs:
 matrix:
   exclude:
     - distros:
-        - fedora-27-x86_64
+        - fedora-28-x86_64
       version: "2.7"
     - distros:
-        - fedora-27-x86_64
+        - fedora-28-x86_64
       version: "3.5"

--- a/src/fedora/macros.tpl
+++ b/src/fedora/macros.tpl
@@ -11,7 +11,6 @@ ENV NAME=python3 \
       name="$FGC/$NAME" \
       version="$VERSION" \
       release="$RELEASE.$DISTTAG" \
-      architecture="$ARCH" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir={{
           spec.version }}/test/setup-test-app/ $FGC/$NAME python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
@@ -21,4 +20,10 @@ ENV NAME=python3 \
 RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P
+
+# For Fedora scl_enable isn't sourced automatically in s2i-core
+# so virtualenv needs to be activated this way
+ENV BASH_ENV="${APP_ROOT}/bin/activate" \
+    ENV="${APP_ROOT}/bin/activate" \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 {% endmacro %}


### PR DESCRIPTION
- scl_enable isn't sourced automatically in s2i-core because it
would cause 'scl_source: No such file or directory' errors in most
of the images

Remove arch label - 'Optional: if omitted, it will be built for
all supported Fedora Architectures'

@pkubatrh @torsava Please review and merge.