### PR TITLE
Fedora should use scl_enable script as others

### DIFF
--- a/3.6/Dockerfile.fedora
+++ b/3.6/Dockerfile.fedora
@@ -12,6 +12,13 @@ ENV PYTHON_VERSION=3.6 \
     LANG=en_US.UTF-8 \
     PIP_NO_CACHE_DIR=off
 
+# RHEL7 base images atomatically set these envvars to run scl_enable. RHEl8
+# images, however, don't as most images don't need SCLs any more. But we want
+# to run it even on RHEL8, because we set the virtualenv environment as part of
+# that script
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
 
 ENV NAME=python3 \
     VERSION=0 \
@@ -60,12 +67,6 @@ COPY ./root/ /
 RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
-ENV BASH_ENV="${APP_ROOT}/bin/activate" \
-    ENV="${APP_ROOT}/bin/activate" \
-    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001
 

--- a/3.7/Dockerfile.fedora
+++ b/3.7/Dockerfile.fedora
@@ -12,6 +12,13 @@ ENV PYTHON_VERSION=3.7 \
     LANG=en_US.UTF-8 \
     PIP_NO_CACHE_DIR=off
 
+# RHEL7 base images atomatically set these envvars to run scl_enable. RHEl8
+# images, however, don't as most images don't need SCLs any more. But we want
+# to run it even on RHEL8, because we set the virtualenv environment as part of
+# that script
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
 
 ENV NAME=python3 \
     VERSION=0 \
@@ -60,12 +67,6 @@ COPY ./root/ /
 RUN virtualenv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
-ENV BASH_ENV="${APP_ROOT}/bin/activate" \
-    ENV="${APP_ROOT}/bin/activate" \
-    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001
 

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -20,7 +20,7 @@ ENV PYTHON_VERSION={{ spec.version }} \
     LANG=en_US.UTF-8 \
     PIP_NO_CACHE_DIR=off
 
-{% if spec.el_version == '8' %}
+{% if spec.el_version != '7' %}{# Applies for RHEL/Centos 8 and Fedora #}
 # RHEL7 base images atomatically set these envvars to run scl_enable. RHEl8
 # images, however, don't as most images don't need SCLs any more. But we want
 # to run it even on RHEL8, because we set the virtualenv environment as part of

--- a/src/fedora/macros.tpl
+++ b/src/fedora/macros.tpl
@@ -22,10 +22,4 @@ RUN virtualenv ${APP_ROOT} && \
 {% endif %}
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
-ENV BASH_ENV="${APP_ROOT}/bin/activate" \
-    ENV="${APP_ROOT}/bin/activate" \
-    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 {% endmacro %}


### PR DESCRIPTION
Because derived images might add some startup actions into scl_enable script, this script should be used in Fedora as well.
    
Fixes: https://github.com/sclorg/s2i-python-container/issues/325