### PR TITLE
Add missing packages for RHEL-8 builds

### DIFF
--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -41,10 +41,10 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=2.7/test/setup-test-app/ ubi8/python-27 python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python2 python2-devel glibc-langpack-en python2-setuptools python2-pip \
-        python2-virtualenv nss_wrapper httpd httpd-devel mod_ssl \
-        mod_auth_gssapi mod_ldap mod_session atlas-devel gcc-gfortran \
-        libffi-devel libtool-ltdl enchant" && \
+RUN INSTALL_PKGS="python2 python2-devel glibc-langpack-en redhat-rpm-config python2-setuptools \
+        python2-pip python2-virtualenv nss_wrapper httpd httpd-devel \
+        mod_ssl mod_auth_gssapi mod_ldap mod_session atlas-devel \
+        gcc-gfortran libffi-devel libtool-ltdl enchant" && \
     yum -y module enable python27:2.7 httpd:2.4 && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/3.6/Dockerfile.rhel8
+++ b/3.6/Dockerfile.rhel8
@@ -41,10 +41,10 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ubi8/python-36 python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python36 python36-devel glibc-langpack-en python3-setuptools python3-pip \
-        python3-virtualenv nss_wrapper httpd httpd-devel mod_ssl \
-        mod_auth_gssapi mod_ldap mod_session atlas-devel gcc-gfortran \
-        libffi-devel libtool-ltdl enchant" && \
+RUN INSTALL_PKGS="python36 python36-devel glibc-langpack-en redhat-rpm-config python3-setuptools \
+        python3-pip python3-virtualenv nss_wrapper httpd httpd-devel \
+        mod_ssl mod_auth_gssapi mod_ldap mod_session atlas-devel \
+        gcc-gfortran libffi-devel libtool-ltdl enchant" && \
     yum -y module enable python36:3.6 httpd:2.4 && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/3.6/Dockerfile.rhel8
+++ b/3.6/Dockerfile.rhel8
@@ -41,10 +41,10 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ubi8/python-36 python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python36 python36-devel python3-setuptools python3-pip python3-virtualenv \
-        nss_wrapper httpd httpd-devel mod_ssl mod_auth_gssapi \
-        mod_ldap mod_session atlas-devel gcc-gfortran libffi-devel \
-        libtool-ltdl enchant" && \
+RUN INSTALL_PKGS="python36 python36-devel glibc-langpack-en python3-setuptools python3-pip \
+        python3-virtualenv nss_wrapper httpd httpd-devel mod_ssl \
+        mod_auth_gssapi mod_ldap mod_session atlas-devel gcc-gfortran \
+        libffi-devel libtool-ltdl enchant" && \
     yum -y module enable python36:3.6 httpd:2.4 && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -54,8 +54,8 @@ specs:
                   'mod_auth_gssapi', 'mod_ldap', 'mod_session',
                   'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
       extra_pkgs:
-        "2.7": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel', 'glibc-langpack-en']
-        "3.6": ['python36', 'python36-devel', 'glibc-langpack-en']
+        "2.7": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel', 'glibc-langpack-en', 'redhat-rpm-config']
+        "3.6": ['python36', 'python36-devel', 'glibc-langpack-en', 'redhat-rpm-config']
 
     fedora28:
       distros:

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -55,7 +55,7 @@ specs:
                   'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
       extra_pkgs:
         "2.7": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel', 'glibc-langpack-en']
-        "3.6": ['python36', 'python36-devel']
+        "3.6": ['python36', 'python36-devel', 'glibc-langpack-en']
 
     fedora28:
       distros:


### PR DESCRIPTION
During rebuild of 8.1.0 containers, there have been two issues:

1) There was an issue with setting locales, the test log was full of those warnings:
```
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
```
I admin I don't understand the whole story here, but saw installing `glibc-langpack-en` in `ubi8/python-27` image, and the same works for `ubi8/pyton-36` image. So, this is a suggested fix for this issue as well.

2) During `mod-wsgi-test-app` test, we saw this issue:
```
gcc: error: /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
```
Since `/usr/lib/rpm/redhat/redhat-hardened-cc1` is shipped by `redhat-rpm-config` on RHEL-8.1, adding this package helped. Again, it is not clear to me what changed since RHEL-8.0 or why it works fine on other distros.