### PR TITLE
[WIP] Add  s2i-python-container/3.6/Dockerfile.centos8

### DIFF
--- a/3.6/Dockerfile.centos8
+++ b/3.6/Dockerfile.centos8
@@ -1,0 +1,75 @@
+# This image provides a Python 3.6 environment you can use to run your Python
+# applications.
+FROM centos/s2i-base-centos8
+
+EXPOSE 8080
+
+ENV PYTHON_VERSION=3.6 \
+    PATH=$HOME/.local/bin/:$PATH \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    PIP_NO_CACHE_DIR=off
+
+# RHEL7 base images atomatically set these envvars to run scl_enable. RHEl8
+# images, however, don't as most images don't need SCLs any more. But we want
+# to run it even on RHEL8, because we set the virtualenv environment as part of
+# that script
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+
+ENV SUMMARY="Platform for building and running Python $PYTHON_VERSION applications" \
+    DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \
+building and running various Python $PYTHON_VERSION applications and frameworks. \
+Python is an easy to learn, powerful programming language. It has efficient high-level \
+data structures and a simple but effective approach to object-oriented programming. \
+Python's elegant syntax and dynamic typing, together with its interpreted nature, \
+make it an ideal language for scripting and rapid application development in many areas \
+on most platforms."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Python 3.6" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,python,python36,python-36,rh-python36" \
+      com.redhat.component="python-36-container" \
+      name="centos8/python-36" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ubi8/python-36 python-sample-app" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+RUN INSTALL_PKGS="python36 python36-devel python3-setuptools python3-pip python3-virtualenv \
+        nss_wrapper httpd httpd-devel mod_ssl mod_auth_gssapi \
+        mod_ldap mod_session atlas-devel gcc-gfortran libffi-devel \
+        libtool-ltdl enchant" && \
+    yum -y module enable python36:3.6 httpd:2.4 && \
+    yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    # Remove redhat-logos-httpd (httpd dependency) to keep image size smaller.
+    # rpm -e --nodeps redhat-logos-httpd && \
+    yum -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY ./s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY ./root/ /
+
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
+RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image.
+CMD $STI_SCRIPTS_PATH/usage


### PR DESCRIPTION
Dockerfiles for centos8. Derived from the rhel8 and centos7 files.

I have successfully made builds by changing the build and tag script to include centos8 dockerfiles.
@pkubatrh @hhorak Sadly i am not sure about whether i can or should upgrade the common submodule that includes build.sh and tag.sh.

[build_scripts.zip](https://github.com/sclorg/s2i-python-container/files/3741412/build_scripts.zip)

In https://github.com/sclorg/s2i-base-container/pull/194 i  successfully built the core and base images and used them for https://hub.docker.com/r/jvonkoho/python-36 which is working fine as replacement for centos/python-36-centos7.