### PR TITLE
Fix example app name in 3.7 README

### DIFF
--- a/3.7/README.md
+++ b/3.7/README.md
@@ -35,7 +35,7 @@ Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-conta
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.6~https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/
+    oc new-app python:3.7~https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/
     ```
 
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:


### PR DESCRIPTION
The README for Python 3.7 still uses _python3.6_ as an example OpenShift app name. Renamed to 3.7.