### PR TITLE
Readme cleanups

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -32,7 +32,7 @@ the nodejs itself is included just to make the npm work.
 Usage
 ---------------------
 
-For this, we will assume that you are using the `rhscl/python-27-rhel7 image`, available via `python:2.7` imagestream tag in Openshift.
+For this, we will assume that you are using the supported image, available via `python:2.7` imagestream tag in Openshift.
 Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-container/tree/master/2.7/test/setup-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -43,7 +43,7 @@ in Openshift can be achieved with the following step:
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
 
     ```
-    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=2.7/test/setup-test-app/ rhscl/python-27-rhel7 python-sample-app
+    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=2.7/test/setup-test-app/ <image_name> python-sample-app
     ```
 
 **Accessing the application:**

--- a/2.7/README.md
+++ b/2.7/README.md
@@ -46,6 +46,8 @@ The same application can also be built using the standalone [S2I](https://github
     $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=2.7/test/setup-test-app/ <image_name> python-sample-app
     ```
 
+Where `<image_name>` is the s2i-python image you [downloaded from RHEL, Centos or Fedora registry](../README.md#Download) or [built](../README.md#Build) from these sources. For example ubi8/python-36, centos/python-36-centos7 or f31/python3.
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -46,6 +46,8 @@ The same application can also be built using the standalone [S2I](https://github
     $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ <image_name> python-sample-app
     ```
 
+Where `<image_name>` is the s2i-python image you [downloaded from RHEL, Centos or Fedora registry](../README.md#Download) or [built](../README.md#Build) from these sources. For example ubi8/python-36, centos/python-36-centos7 or f31/python3.
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -32,7 +32,7 @@ the nodejs itself is included just to make the npm work.
 Usage
 ---------------------
 
-For this, we will assume that you are using the `rhscl/python-36-rhel7 image`, available via `python:3.6` imagestream tag in Openshift.
+For this, we will assume that you are using the supported image, available via `python:3.6` imagestream tag in Openshift.
 Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-container/tree/master/3.6/test/setup-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -43,7 +43,7 @@ in Openshift can be achieved with the following step:
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
 
     ```
-    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ rhscl/python-36-rhel7 python-sample-app
+    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ <image_name> python-sample-app
     ```
 
 **Accessing the application:**

--- a/3.7/README.md
+++ b/3.7/README.md
@@ -32,7 +32,7 @@ the nodejs itself is included just to make the npm work.
 Usage
 ---------------------
 
-For this, we will assume that you are using the `rhscl/python-37-rhel7 image`, available via `python:3.7` imagestream tag in Openshift.
+For this, we will assume that you are using the supported image, available via `python:3.7` imagestream tag in Openshift.
 Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-container/tree/master/3.7/test/setup-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -43,7 +43,7 @@ in Openshift can be achieved with the following step:
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
 
     ```
-    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/ rhscl/python-37-rhel7 python-sample-app
+    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/ <image_name> python-sample-app
     ```
 
 **Accessing the application:**

--- a/3.7/README.md
+++ b/3.7/README.md
@@ -46,6 +46,8 @@ The same application can also be built using the standalone [S2I](https://github
     $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/ <image_name> python-sample-app
     ```
 
+Where `<image_name>` is the s2i-python image you [downloaded from RHEL, Centos or Fedora registry](../README.md#Download) or [built](../README.md#Build) from these sources. For example ubi8/python-36, centos/python-36-centos7 or f31/python3.
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/3.8/README.md
+++ b/3.8/README.md
@@ -46,6 +46,8 @@ The same application can also be built using the standalone [S2I](https://github
     $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.8/test/setup-test-app/ <image_name> python-sample-app
     ```
 
+Where `<image_name>` is the s2i-python image you [downloaded from RHEL, Centos or Fedora registry](../README.md#Download) or [built](../README.md#Build) from these sources. For example ubi8/python-36, centos/python-36-centos7 or f31/python3.
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/3.8/README.md
+++ b/3.8/README.md
@@ -32,7 +32,7 @@ the nodejs itself is included just to make the npm work.
 Usage
 ---------------------
 
-For this, we will assume that you are using the `rhscl/python-38-rhel7 image`, available via `python:3.8` imagestream tag in Openshift.
+For this, we will assume that you are using the supported image, available via `python:3.8` imagestream tag in Openshift.
 Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-container/tree/master/3.8/test/setup-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -43,7 +43,7 @@ in Openshift can be achieved with the following step:
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
 
     ```
-    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.8/test/setup-test-app/ rhscl/python-38-rhel7 python-sample-app
+    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.8/test/setup-test-app/ <image_name> python-sample-app
     ```
 
 **Accessing the application:**

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ official [OpenShift Documentation](https://docs.okd.io/latest/using_images/s2i_i
 For more information about concepts used in these container images, see the
 [Landing page](https://github.com/sclorg/welcome).
 
+Note: while the examples in this README are calling `podman`, you can replace any such calls by `docker` with the same arguments
+
 Contributing
 ---------------
 In this repository [distgen](https://github.com/devexp-db/distgen/) > 1.0 is used for generating directories for Python versions. Also make sure distgen imports the jinja2 package >= 2.10.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Python versions currently provided are:
 * [python-3.8](3.8)
 
 RHEL versions currently supported are:
-* RHEL 7 ([catalog.redhat.com](https://catalog.redhat.com/software/containers))
-* RHEL 8 ([catalog.redhat.com](https://catalog.redhat.com/software/containers))
+* RHEL 7 ([catalog.redhat.com](https://catalog.redhat.com/software/containers/search))
+* RHEL 8 ([catalog.redhat.com](https://catalog.redhat.com/software/containers/search))
 
 CentOS versions currently supported are:
 * CentOS 7 ([hub.docker.com](https://hub.docker.com/r/centos/))

--- a/README.md
+++ b/README.md
@@ -41,102 +41,76 @@ Python versions currently provided are:
 * [python-3.8](3.8)
 
 RHEL versions currently supported are:
-* RHEL7
+* RHEL 7 ([catalog.redhat.com](https://catalog.redhat.com/software/containers))
+* RHEL 8 ([catalog.redhat.com](https://catalog.redhat.com/software/containers))
 
 CentOS versions currently supported are:
-* CentOS7
+* CentOS 7 ([hub.docker.com](https://hub.docker.com/r/centos/))
 
+Fedora versions currently supported are:
+* Fedora 31 ([registry.fedoraproject.org](https://registry.fedoraproject.org/repo/f31/python3/tags/))
+* Fedora 32 ([registry.fedoraproject.org](https://registry.fedoraproject.org/repo/f32/python3/tags/))
 
-Installation
----------------
-To build a Python image, choose either the CentOS or RHEL based image:
-*  **RHEL based image**
+Download
+--------
+To download one of the base Python images, follow the instructions you find in registries mentioned above.
 
-    These images are available in the [Red Hat Container Catalog](https://access.redhat.com/containers/#/registry.access.redhat.com/rhscl/python-36-rhel7).
-    To download it run:
+For example, Centos image can be downloaded via:
 
-    ```
-    $ podman pull registry.access.redhat.com/rhscl/python-36-rhel7
-    ```
+```
+$ podman pull centos/python-36-centos7
+```
 
-    To build a RHEL based Python image, you need to run the build on a properly
-    subscribed RHEL machine.
+Build
+-----
+To build a Python image from scratch run:
 
-    ```
-    $ git clone https://github.com/sclorg/s2i-python-container.git
-    $ cd s2i-python-container
-    $ make build TARGET=rhel7 VERSIONS=3.6
-    ```
+```
+$ git clone https://github.com/sclorg/s2i-python-container.git
+$ cd s2i-python-container
+$ make build TARGET=centos7 VERSIONS=3.6
+```
 
-*  **CentOS based image**
-
-    This image is available on DockerHub. To download it run:
-
-    ```
-    $ podman pull centos/python-36-centos7
-    ```
-
-    To build a Python image from scratch run:
-
-    ```
-    $ git clone https://github.com/sclorg/s2i-python-container.git
-    $ cd s2i-python-container
-    $ make build TARGET=centos7 VERSIONS=3.6
-    ```
-
-Note: while the installation steps are calling `podman`, you can replace any such calls by `docker` with the same arguments.
+Where `TARGET` might be one of the supported platforms mentioned above.
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
 on all provided versions of Python.**
 
-
 Usage
----------------------------------
-
-For information about usage of Dockerfile for Python 2.7,
-see [usage documentation](2.7/README.md).
-
-For information about usage of Dockerfile for Python 3.6,
-see [usage documentation](3.6/README.md).
+-----
+For information about usage of S2I Python images, see the documentation for each version in its folder.
 
 Test
----------------------
+----
 This repository also provides a [S2I](https://github.com/openshift/source-to-image) test framework,
-which launches tests to check functionality of a simple Python application built on top of the s2i-python-container image.
+which launches tests to check functionality of simple Python applications built on top of the s2i-python-container image.
 
-Users can choose between testing a Python test application based on a RHEL or CentOS image.
+```
+$ cd s2i-python-container
+$ make test TARGET=centos7 VERSIONS=3.6
+```
 
-*  **RHEL based image**
-
-    To test a RHEL7-based Python image, you need to run the test on a properly subscribed RHEL machine.
-
-    ```
-    $ cd s2i-python-container
-    $ make test TARGET=rhel7 VERSIONS=3.6
-    ```
-
-*  **CentOS based image**
-
-    ```
-    $ cd s2i-python-container
-    $ make test TARGET=centos7 VERSIONS=3.6
-    ```
+Where `TARGET` might be one of the supported platforms mentioned above.
 
 **Notice: By omitting the `VERSIONS` parameter, the build/test action will be performed
 on all provided versions of Python.**
 
 
 Repository organization
-------------------------
+-----------------------
 * **`<python-version>`**
 
     * **Dockerfile**
 
         CentOS based Dockerfile.
 
-    * **Dockerfile.rhel7**
+    * **Dockerfile.fedora**
 
-        RHEL based Dockerfile. In order to perform build or test actions on this
+        Fedora based Dockerfile.
+
+    * **Dockerfile.rhel7** & **Dockerfile.rhel8**
+
+        RHEL 7/8 based Dockerfile. In order to perform build or test actions on this
         Dockerfile you need to run the action on a properly subscribed RHEL machine.
 
     * **`s2i/bin/`**
@@ -158,22 +132,10 @@ Repository organization
 
             This script prints the usage of this image.
 
-    * **`contrib/`**
-
-        This folder contains a file with commonly used modules.
-
     * **`test/`**
 
         This folder contains a [S2I](https://github.com/openshift/source-to-image)
-        test framework with a simple server.
-
-        * **`setup-test-app/`**
-
-            Simple Gunicorn application used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
-
-        * **`standalone-test-app/`**
-
-            Simple standalone application used for testing purposes by the [S2I](https://github.com/openshift/source-to-image) test framework.
+        test framework with multiple test aplications testing different approaches.
 
         * **run**
 

--- a/src/README.md
+++ b/src/README.md
@@ -46,6 +46,8 @@ The same application can also be built using the standalone [S2I](https://github
     $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir={{ spec.version }}/test/setup-test-app/ <image_name> python-sample-app
     ```
 
+Where `<image_name>` is the s2i-python image you [downloaded from RHEL, Centos or Fedora registry](../README.md#Download) or [built](../README.md#Build) from these sources. For example ubi8/python-36, centos/python-36-centos7 or f31/python3.
+
 **Accessing the application:**
 ```
 $ curl 127.0.0.1:8080

--- a/src/README.md
+++ b/src/README.md
@@ -32,7 +32,7 @@ the nodejs itself is included just to make the npm work.
 Usage
 ---------------------
 
-For this, we will assume that you are using the `rhscl/python-{{ spec.short_ver }}-rhel7 image`, available via `python:{{ spec.version }}` imagestream tag in Openshift.
+For this, we will assume that you are using the supported image, available via `python:{{ spec.version }}` imagestream tag in Openshift.
 Building a simple [python-sample-app](https://github.com/sclorg/s2i-python-container/tree/master/{{ spec.version }}/test/setup-test-app) application
 in Openshift can be achieved with the following step:
 
@@ -43,7 +43,7 @@ in Openshift can be achieved with the following step:
 The same application can also be built using the standalone [S2I](https://github.com/openshift/source-to-image) application on systems that have it available:
 
     ```
-    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir={{ spec.version }}/test/setup-test-app/ rhscl/python-{{ spec.short_ver }}-rhel7 python-sample-app
+    $ s2i build https://github.com/sclorg/s2i-python-container.git --context-dir={{ spec.version }}/test/setup-test-app/ <image_name> python-sample-app
     ```
 
 **Accessing the application:**


### PR DESCRIPTION
The purpose of this change is to make the readme files more general and lower the possibility of a mistake when we support many versions of Python but some of them only on specific platforms. Also, it's not necessary to show multiple examples when the only difference is in one word. Another thing is that we copy those files to downstream repositories and it does not make really sense to have RHEL examples in Fedora repository.

Cc @torsava 