### PR TITLE
Python venv

### DIFF
--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -65,7 +65,8 @@ COPY ./root/ /
 # - In order to drop the root user, we have to make some directories world
 #   writable as OpenShift default security model is to run the container
 #   under random UID.
-RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
+RUN \
+    virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions

--- a/3.6/Dockerfile.rhel8
+++ b/3.6/Dockerfile.rhel8
@@ -65,7 +65,8 @@ COPY ./root/ /
 # - In order to drop the root user, we have to make some directories world
 #   writable as OpenShift default security model is to run the container
 #   under random UID.
-RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
+RUN \
+    virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions

--- a/3.7/Dockerfile.fedora
+++ b/3.7/Dockerfile.fedora
@@ -57,7 +57,7 @@ COPY ./root/ /
 # - In order to drop the root user, we have to make some directories world
 #   writable as OpenShift default security model is to run the container
 #   under random UID.
-RUN virtualenv ${APP_ROOT} && \
+RUN python3.7 -m venv ${APP_ROOT} && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P
 

--- a/3.7/s2i/bin/assemble
+++ b/3.7/s2i/bin/assemble
@@ -9,13 +9,9 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-     head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7" || \
-     head "/etc/redhat-release" | grep -q "^Fedora release"; then
-    virtualenv $1
-  else
-    virtualenv-${PYTHON_VERSION} $1
-  fi
+    # New versions of Python (>3.6) should use venv module
+    # from stdlib instead of virtualenv package
+    python3.7 -m venv $1
 }
 
 # Install pipenv to the separate virtualenv to isolate it

--- a/3.8/Dockerfile.fedora
+++ b/3.8/Dockerfile.fedora
@@ -57,7 +57,7 @@ COPY ./root/ /
 # - In order to drop the root user, we have to make some directories world
 #   writable as OpenShift default security model is to run the container
 #   under random UID.
-RUN virtualenv ${APP_ROOT} && \
+RUN python3.8 -m venv ${APP_ROOT} && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P
 

--- a/3.8/s2i/bin/assemble
+++ b/3.8/s2i/bin/assemble
@@ -9,13 +9,9 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
-  if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-     head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7" || \
-     head "/etc/redhat-release" | grep -q "^Fedora release"; then
-    virtualenv $1
-  else
-    virtualenv-${PYTHON_VERSION} $1
-  fi
+    # New versions of Python (>3.6) should use venv module
+    # from stdlib instead of virtualenv package
+    python3.8 -m venv $1
 }
 
 # Install pipenv to the separate virtualenv to isolate it

--- a/src/centos/macros.tpl
+++ b/src/centos/macros.tpl
@@ -27,11 +27,19 @@ python
 {% endmacro %}
 
 {% macro permissions_setup(spec) %}
+{# Enable SCL only for RHEL 7 #}
 {% if spec.el_version == '7' %}
 RUN source scl_source enable {{ spec.scl }} && \
+{% else %}
+RUN \
+{% endif %}
+{# Use different virtualenv command of venv module based on Python and platform version #}
+{% if spec.version not in ["2.7", "3.6"] %}
+    python{{ spec.version }} -m venv ${APP_ROOT} && \
+{% elif spec.el_version == '7' %}
     virtualenv ${APP_ROOT} && \
 {% else %}
-RUN virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
+    virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
 {% endif %}
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \

--- a/src/fedora/macros.tpl
+++ b/src/fedora/macros.tpl
@@ -15,7 +15,7 @@ ENV NAME=python3 \
 {% endmacro %}
 
 {% macro permissions_setup(spec) %}
-RUN virtualenv ${APP_ROOT} && \
+RUN python{{ spec.version }} -m venv ${APP_ROOT} && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P
 

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -9,6 +9,11 @@ function should_collectstatic() {
 }
 
 function virtualenv_bin() {
+  {% if spec.version not in ["2.7", "3.6"] %}
+    # New versions of Python (>3.6) should use venv module
+    # from stdlib instead of virtualenv package
+    python{{ spec.version }} -m venv $1
+  {% else %}
   if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
      head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7" || \
      head "/etc/redhat-release" | grep -q "^Fedora release"; then
@@ -16,6 +21,7 @@ function virtualenv_bin() {
   else
     virtualenv-${PYTHON_VERSION} $1
   fi
+  {% endif %}
 }
 
 # Install pipenv to the separate virtualenv to isolate it


### PR DESCRIPTION
For Python >= 3.8 use `venv` module from stdlib instead of virtualenv package. `venv` has less features but will be easier to maintain since it's part of Python itself.