### PR TITLE
Add Python 3.8 for RHEL8 and preparation for RHEL7 and CentOS

### DIFF
--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -42,8 +42,8 @@ LABEL summary="$SUMMARY" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python2 python2-devel glibc-langpack-en python2-setuptools python2-pip \
-        python2-virtualenv nss_wrapper httpd httpd-devel mod_ssl \
+RUN INSTALL_PKGS="python2 python2-devel glibc-langpack-en python2-virtualenv python2-setuptools \
+        python2-pip nss_wrapper httpd httpd-devel mod_ssl \
         mod_auth_gssapi mod_ldap mod_session atlas-devel gcc-gfortran \
         libffi-devel libtool-ltdl enchant" && \
     yum -y module enable python27:2.7 httpd:2.4 && \

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -197,7 +197,10 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-for app in ${WEB_APPS[@]}; do
+# For debugging purposes, this script can be run with one or more arguments
+# those arguments list is a sub-set of values in the WEB_APPS array defined above
+# Example: ./run app-home-test-app pipenv-test-app
+for app in ${@:-${WEB_APPS[@]}}; do
   prepare ${app}
   run_s2i_build ${app}
   RESULT=$?

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -197,7 +197,10 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-for app in ${WEB_APPS[@]}; do
+# For debugging purposes, this script can be run with one or more arguments
+# those arguments list is a sub-set of values in the WEB_APPS array defined above
+# Example: ./run app-home-test-app pipenv-test-app
+for app in ${@:-${WEB_APPS[@]}}; do
   prepare ${app}
   run_s2i_build ${app}
   RESULT=$?

--- a/3.7/Dockerfile.fedora
+++ b/3.7/Dockerfile.fedora
@@ -38,9 +38,9 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.7/test/setup-test-app/ $FGC/$NAME python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip python3-virtualenv \
-        nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran \
-        libffi-devel libtool-ltdl enchant redhat-rpm-config" && \
+RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip nss_wrapper \
+        httpd httpd-devel atlas-devel gcc-gfortran libffi-devel \
+        libtool-ltdl enchant redhat-rpm-config" && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*'

--- a/3.7/test/run
+++ b/3.7/test/run
@@ -197,7 +197,10 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-for app in ${WEB_APPS[@]}; do
+# For debugging purposes, this script can be run with one or more arguments
+# those arguments list is a sub-set of values in the WEB_APPS array defined above
+# Example: ./run app-home-test-app pipenv-test-app
+for app in ${@:-${WEB_APPS[@]}}; do
   prepare ${app}
   run_s2i_build ${app}
   RESULT=$?

--- a/3.8/Dockerfile.fedora
+++ b/3.8/Dockerfile.fedora
@@ -38,9 +38,9 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.8/test/setup-test-app/ $FGC/$NAME python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip python3-virtualenv \
-        nss_wrapper httpd httpd-devel atlas-devel gcc-gfortran \
-        libffi-devel libtool-ltdl enchant redhat-rpm-config" && \
+RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip nss_wrapper \
+        httpd httpd-devel atlas-devel gcc-gfortran libffi-devel \
+        libtool-ltdl enchant redhat-rpm-config" && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*'

--- a/3.8/Dockerfile.rhel8
+++ b/3.8/Dockerfile.rhel8
@@ -1,10 +1,10 @@
-# This image provides a Python 3.6 environment you can use to run your Python
+# This image provides a Python 3.8 environment you can use to run your Python
 # applications.
 FROM ubi8/s2i-base:1
 
 EXPOSE 8080
 
-ENV PYTHON_VERSION=3.6 \
+ENV PYTHON_VERSION=3.8 \
     PATH=$HOME/.local/bin/:$PATH \
     PYTHONUNBUFFERED=1 \
     PYTHONIOENCODING=UTF-8 \
@@ -32,21 +32,20 @@ on most platforms."
 LABEL summary="$SUMMARY" \
       description="$DESCRIPTION" \
       io.k8s.description="$DESCRIPTION" \
-      io.k8s.display-name="Python 3.6" \
+      io.k8s.display-name="Python 3.8" \
       io.openshift.expose-services="8080:http" \
-      io.openshift.tags="builder,python,python36,python-36,rh-python36" \
-      com.redhat.component="python-36-container" \
-      name="ubi8/python-36" \
+      io.openshift.tags="builder,python,python38,python-38,rh-python38" \
+      com.redhat.component="python-38-container" \
+      name="ubi8/python-38" \
       version="1" \
-      usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ubi8/python-36 python-sample-app" \
+      usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.8/test/setup-test-app/ ubi8/python-38 python-sample-app" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python36 python36-devel python3-virtualenv python3-setuptools python3-pip \
-        nss_wrapper httpd httpd-devel mod_ssl mod_auth_gssapi \
-        mod_ldap mod_session atlas-devel gcc-gfortran libffi-devel \
-        libtool-ltdl enchant" && \
-    yum -y module enable python36:3.6 httpd:2.4 && \
+RUN INSTALL_PKGS="python38 python38-devel python38-setuptools python38-pip nss_wrapper \
+        httpd httpd-devel mod_ssl mod_auth_gssapi mod_ldap \
+        mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl enchant" && \
+    yum -y module enable python38:3.8 httpd:2.4 && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos-httpd (httpd dependency) to keep image size smaller.
@@ -66,7 +65,7 @@ COPY ./root/ /
 #   writable as OpenShift default security model is to run the container
 #   under random UID.
 RUN \
-    virtualenv-$PYTHON_VERSION ${APP_ROOT} && \
+    python3.8 -m venv ${APP_ROOT} && \
     chown -R 1001:0 ${APP_ROOT} && \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions

--- a/3.8/test/run
+++ b/3.8/test/run
@@ -197,7 +197,10 @@ check_result $?
 test_docker_run_usage
 check_result $?
 
-for app in ${WEB_APPS[@]}; do
+# For debugging purposes, this script can be run with one or more arguments
+# those arguments list is a sub-set of values in the WEB_APPS array defined above
+# Example: ./run app-home-test-app pipenv-test-app
+for app in ${@:-${WEB_APPS[@]}}; do
   prepare ${app}
   run_s2i_build ${app}
   RESULT=$?

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -81,20 +81,20 @@ specs:
                   'libffi-devel', 'libtool-ltdl enchant', 'redhat-rpm-config']
 
   version:
-    "3.7":
-      version: "3.7"
-      short_ver: "37"
-      base_img_version: "1"
-      python_img_version: "1"
-      scl: "rh-python37"
-      pkg_prefix: "python3"
-
     "3.8":
       version: "3.8"
       short_ver: "38"
       base_img_version: "1"
       python_img_version: "1"
       scl: "rh-python38"
+      pkg_prefix: "python3"
+
+    "3.7":
+      version: "3.7"
+      short_ver: "37"
+      base_img_version: "1"
+      python_img_version: "1"
+      scl: "rh-python37"
       pkg_prefix: "python3"
 
     "3.6":

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -64,8 +64,7 @@ specs:
       fedora_version: "31"
       s2i_base: registry.fedoraproject.org/f31/s2i-base
       img_tag: "latest"
-      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip',
-                    'python3-virtualenv']
+      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
       base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'atlas-devel', 'gcc-gfortran',
                   'libffi-devel', 'libtool-ltdl enchant', 'redhat-rpm-config']
 
@@ -75,8 +74,7 @@ specs:
       fedora_version: "32"
       s2i_base: registry.fedoraproject.org/f32/s2i-base
       img_tag: "latest"
-      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip',
-                    'python3-virtualenv']
+      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
       base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'atlas-devel', 'gcc-gfortran',
                   'libffi-devel', 'libtool-ltdl enchant', 'redhat-rpm-config']
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -36,7 +36,7 @@ specs:
       base_pkgs: ['nss_wrapper', 'httpd24', 'httpd24-httpd-devel', 'httpd24-mod_ssl',
                   'httpd24-mod_auth_kerb', 'httpd24-mod_ldap', 'httpd24-mod_session',
                   'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
-      ubi_versions: ['2.7', '3.6']
+      ubi_versions: ['2.7', '3.6', '3.8']
 
     rhel8:
       distros:
@@ -48,15 +48,16 @@ specs:
       prod: "rhel8"
       logos: "redhat-logos-httpd"
       preinstall_cmd: ['yum -y module enable {{ spec.module_stream }} httpd:2.4']
-      python_pkgs: ['{{ spec.pkg_prefix }}-setuptools', '{{ spec.pkg_prefix }}-pip',
-                    '{{ spec.pkg_prefix }}-virtualenv']
+      python_pkgs: ['{{ spec.pkg_prefix }}-setuptools', '{{ spec.pkg_prefix }}-pip']
       base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'mod_ssl',
                   'mod_auth_gssapi', 'mod_ldap', 'mod_session',
                   'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
       extra_pkgs:
-        "2.7": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel', 'glibc-langpack-en']
-        "3.6": ['python36', 'python36-devel']
-      ubi_versions: ['2.7', '3.6']
+        "2.7": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel', 'glibc-langpack-en',
+                    '{{ spec.pkg_prefix }}-virtualenv']
+        "3.6": ['python36', 'python36-devel', '{{ spec.pkg_prefix }}-virtualenv']
+        "3.8": ['{{ spec.pkg_prefix }}', '{{ spec.pkg_prefix }}-devel']
+      ubi_versions: ['2.7', '3.6', '3.8']
 
     fedora31:
       distros:
@@ -85,7 +86,8 @@ specs:
       base_img_version: "1"
       python_img_version: "1"
       scl: "rh-python38"
-      pkg_prefix: "python3"
+      module_stream: "python38:3.8"
+      pkg_prefix: "python38"
 
     "3.7":
       version: "3.7"
@@ -131,5 +133,4 @@ matrix:
         - centos-7-x86_64
         - fedora-31-x86_64
         - rhel-7-x86_64
-        - rhel-8-x86_64
       version: "3.8"


### PR DESCRIPTION
Note that rh-python38 container for EL7 still uses virtualenv instead of venv in distgit. But I think it's time to update it to venv.