### PR TITLE
[WIP] Use refactored functions and enable testing in remote OCP4

### DIFF
--- a/2.7/test/imagestreams
+++ b/2.7/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/2.7/test/test-lib-python.sh
+++ b/2.7/test/test-lib-python.sh
@@ -1,0 +1,1 @@
+../../test/test-lib-python.sh

--- a/3.6/test/imagestreams
+++ b/3.6/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/3.6/test/test-lib-python.sh
+++ b/3.6/test/test-lib-python.sh
@@ -1,0 +1,1 @@
+../../test/test-lib-python.sh

--- a/3.7/test/imagestreams
+++ b/3.7/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/3.7/test/test-lib-python.sh
+++ b/3.7/test/test-lib-python.sh
@@ -1,0 +1,1 @@
+../../test/test-lib-python.sh

--- a/3.8/test/imagestreams
+++ b/3.8/test/imagestreams
@@ -1,0 +1,1 @@
+../../imagestreams

--- a/3.8/test/test-lib-python.sh
+++ b/3.8/test/test-lib-python.sh
@@ -1,0 +1,1 @@
+../../test/test-lib-python.sh

--- a/manifest.sh
+++ b/manifest.sh
@@ -96,6 +96,12 @@ SYMLINK_RULES="
 
     link_target=../../common/test-lib-openshift.sh
     link_name=test/test-lib-openshift.sh;
+
+    link_target=../../test/test-lib-python.sh
+    link_name=test/test-lib-python.sh;
+
+    link_target=../../imagestreams
+    link_name=test/imagestreams;
 "
 
 # Files to copy

--- a/test/imagestreams
+++ b/test/imagestreams
@@ -1,0 +1,1 @@
+../imagestreams/

--- a/test/run-openshift
+++ b/test/run-openshift
@@ -28,18 +28,17 @@ fi
 
 ct_os_cluster_up
 
-#ct_os_test_s2i_app "${IMAGE_NAME}" "${THISDIR}/standalone-test-app" . "Hello World from standalone WSGI application!"
+ct_os_test_s2i_app "${IMAGE_NAME}" "${THISDIR}/standalone-test-app" . "Hello World from standalone WSGI application!"
 
-#ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
+ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
 
 for template in $EPHEMERAL_TEMPLATES; do
-:
-#    ct_os_test_template_app "$IMAGE_NAME" \
-#                            "$template" \
-#                            python \
-#                            'Welcome to your Django application on OpenShift' \
-#                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
-#                            "centos/postgresql-96-centos7|postgresql:9.6"
+    ct_os_test_template_app "$IMAGE_NAME" \
+                            "$template" \
+                            python \
+                            'Welcome to your Django application on OpenShift' \
+                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
+                            "centos/postgresql-96-centos7|postgresql:9.6"
 done
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -33,17 +33,16 @@ https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/dj
 https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/django-postgresql.json"
 fi
 
-#ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-python-container.git" "examples/standalone-test-app" "Hello World from standalone WSGI application!"
-#ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
+ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-python-container.git" "examples/standalone-test-app" "Hello World from standalone WSGI application!"
+ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
 
 for template in $EPHEMERAL_TEMPLATES; do
-:
-#    ct_os_test_template_app "$IMAGE_NAME" \
-#                            "$template" \
-#                            python \
-#                            'Welcome to your Django application on OpenShift' \
-#                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
-#                            "centos/postgresql-96-centos7|postgresql:9.6"
+    ct_os_test_template_app "$IMAGE_NAME" \
+                            "$template" \
+                            python \
+                            'Welcome to your Django application on OpenShift' \
+                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
+                            "centos/postgresql-96-centos7|postgresql:9.6"
 done
 
 # Check the imagestream

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -18,7 +18,14 @@ trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
-ct_os_enable_print_logs
+oc status || false "It looks like oc is not properly logged in."
+
+export CT_SKIP_NEW_PROJECT=true
+export CT_SKIP_UPLOAD_IMAGE=true
+export CT_NAMESPACE=openshift
+
+test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
+test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 
 if [ -z "${EPHEMERAL_TEMPLATES:-}" ]; then
     EPHEMERAL_TEMPLATES="
@@ -26,10 +33,7 @@ https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/dj
 https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/django-postgresql.json"
 fi
 
-ct_os_cluster_up
-
-#ct_os_test_s2i_app "${IMAGE_NAME}" "${THISDIR}/standalone-test-app" . "Hello World from standalone WSGI application!"
-
+#ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/s2i-python-container.git" "examples/standalone-test-app" "Hello World from standalone WSGI application!"
 #ct_os_test_s2i_app "${IMAGE_NAME}" "https://github.com/sclorg/django-ex.git" . 'Welcome to your Django application on OpenShift'
 
 for template in $EPHEMERAL_TEMPLATES; do
@@ -46,8 +50,6 @@ done
 test_python_imagestream
 
 OS_TESTSUITE_RESULT=0
-
-ct_os_cluster_down
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:
 

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Functions for tests for the Python image in OpenShift.
+#
+# IMAGE_NAME specifies a name of the candidate image used for testing.
+# The image has to be available before this script is executed.
+#
+
+THISDIR=$(dirname ${BASH_SOURCE[0]})
+
+source "${THISDIR}/test-lib.sh"
+source "${THISDIR}/test-lib-openshift.sh"
+
+# Check the imagestream
+function test_python_imagestream() {
+  case ${OS} in
+    rhel7|centos7) ;;
+    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
+  esac
+
+  ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/python-${OS}.json" \
+                                     'https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json' \
+                                     "${IMAGE_NAME}" \
+                                     'python' \
+                                     'Welcome to your Django application on OpenShift' \
+                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
+                                     "centos/postgresql-96-centos7|postgresql:9.6"
+}
+
+# vim: set tabstop=2:shiftwidth=2:expandtab:
+

--- a/test/test-lib.sh
+++ b/test/test-lib.sh
@@ -1,0 +1,1 @@
+../common/test-lib.sh


### PR DESCRIPTION
This PR combines more changes:

- add image stream test
- adopts new functions refactored in https://github.com/sclorg/container-common-scripts/pull/155/files
- enables tests to be run in a remote OCP4 cluster