### PR TITLE
hotfix: Pipenv version lock

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -63,7 +63,7 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then
-  install_tool "pipenv"
+  install_tool "pipenv" "==2018.11.26"
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
     pipenv install --deploy

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -62,7 +62,7 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then
-  install_tool "pipenv"
+  install_tool "pipenv" "==2018.11.26"
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
     pipenv install --deploy

--- a/3.7/s2i/bin/assemble
+++ b/3.7/s2i/bin/assemble
@@ -58,7 +58,7 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then
-  install_tool "pipenv"
+  install_tool "pipenv" "==2018.11.26"
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
     pipenv install --deploy

--- a/3.8/s2i/bin/assemble
+++ b/3.8/s2i/bin/assemble
@@ -58,7 +58,7 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then
-  install_tool "pipenv"
+  install_tool "pipenv" "==2018.11.26"
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
     pipenv install --deploy

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -71,7 +71,7 @@ if [[ ! -z "$UPGRADE_PIP_TO_LATEST"{% if spec.version in ["2.7"] %} || ! -z "$EN
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then
-  install_tool "pipenv"
+  install_tool "pipenv" "==2018.11.26"
   echo "---> Installing dependencies via pipenv ..."
   if [[ -f Pipfile ]]; then
     pipenv install --deploy


### PR DESCRIPTION
Fixes #382 by locking pipenv version to [2018.11.26](https://pypi.org/project/pipenv/2018.11.26/) which is a [previous release to the current latest](https://pypi.org/project/pipenv/#history)

If there's a better, more robust fix, please close this PR in favor of that one.

This change is abusing the `install_tool`'s `$VENV_DIR/bin/pip --isolated install -U $1$2` notation.