### PR TITLE
Test isolated

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -32,8 +32,8 @@ function install_tool() {
   # have your own PyPI mirror, it will take it from there. If this try fails, try it
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
-  $VENV_DIR/bin/pip install -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
-  if [ $? -ne 0 ]; then
+  # $1$2 combines package name with [extras] or version specifier if is defined as $2```
+  if ! $VENV_DIR/bin/pip install -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
     $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
@@ -63,11 +63,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version 19.3.1 ..."
-pip install -U "pip==19.3.1"
+if ! pip install -U "pip==19.3.1"; then
+  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip==19.3.1"
+fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools wheel
+  if ! pip install -U pip setuptools wheel; then
+    echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+    pip install --isolated -U pip setuptools wheel
+  fi
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then

--- a/2.7/test/micropipenv-test-app/.s2i/environment
+++ b/2.7/test/micropipenv-test-app/.s2i/environment
@@ -1,2 +1,5 @@
 ENABLE_MICROPIPENV=true
 DISABLE_SETUP_PY_PROCESSING=true
+# This tests second try to install micropipenv with --isolated
+# because the first one won't work with following setting
+PIP_INDEX_URL=https://example.com/

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -31,8 +31,8 @@ function install_tool() {
   # have your own PyPI mirror, it will take it from there. If this try fails, try it
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
-  $VENV_DIR/bin/pip install -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
-  if [ $? -ne 0 ]; then
+  # $1$2 combines package name with [extras] or version specifier if is defined as $2```
+  if ! $VENV_DIR/bin/pip install -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
     $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
@@ -62,11 +62,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version 19.3.1 ..."
-pip install -U "pip==19.3.1"
+if ! pip install -U "pip==19.3.1"; then
+  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip==19.3.1"
+fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools wheel
+  if ! pip install -U pip setuptools wheel; then
+    echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+    pip install --isolated -U pip setuptools wheel
+  fi
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then

--- a/3.6/test/micropipenv-test-app/.s2i/environment
+++ b/3.6/test/micropipenv-test-app/.s2i/environment
@@ -1,2 +1,5 @@
 ENABLE_MICROPIPENV=true
 DISABLE_SETUP_PY_PROCESSING=true
+# This tests second try to install micropipenv with --isolated
+# because the first one won't work with following setting
+PIP_INDEX_URL=https://example.com/

--- a/3.7/s2i/bin/assemble
+++ b/3.7/s2i/bin/assemble
@@ -27,8 +27,8 @@ function install_tool() {
   # have your own PyPI mirror, it will take it from there. If this try fails, try it
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
-  $VENV_DIR/bin/pip install -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
-  if [ $? -ne 0 ]; then
+  # $1$2 combines package name with [extras] or version specifier if is defined as $2```
+  if ! $VENV_DIR/bin/pip install -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
     $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
@@ -58,11 +58,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version 19.3.1 ..."
-pip install -U "pip==19.3.1"
+if ! pip install -U "pip==19.3.1"; then
+  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip==19.3.1"
+fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools wheel
+  if ! pip install -U pip setuptools wheel; then
+    echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+    pip install --isolated -U pip setuptools wheel
+  fi
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then

--- a/3.7/test/micropipenv-test-app/.s2i/environment
+++ b/3.7/test/micropipenv-test-app/.s2i/environment
@@ -1,2 +1,5 @@
 ENABLE_MICROPIPENV=true
 DISABLE_SETUP_PY_PROCESSING=true
+# This tests second try to install micropipenv with --isolated
+# because the first one won't work with following setting
+PIP_INDEX_URL=https://example.com/

--- a/3.8/s2i/bin/assemble
+++ b/3.8/s2i/bin/assemble
@@ -27,8 +27,8 @@ function install_tool() {
   # have your own PyPI mirror, it will take it from there. If this try fails, try it
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
-  $VENV_DIR/bin/pip install -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
-  if [ $? -ne 0 ]; then
+  # $1$2 combines package name with [extras] or version specifier if is defined as $2```
+  if ! $VENV_DIR/bin/pip install -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
     $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
@@ -58,11 +58,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version 19.3.1 ..."
-pip install -U "pip==19.3.1"
+if ! pip install -U "pip==19.3.1"; then
+  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip==19.3.1"
+fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools wheel
+  if ! pip install -U pip setuptools wheel; then
+    echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+    pip install --isolated -U pip setuptools wheel
+  fi
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then

--- a/3.8/test/micropipenv-test-app/.s2i/environment
+++ b/3.8/test/micropipenv-test-app/.s2i/environment
@@ -1,2 +1,5 @@
 ENABLE_MICROPIPENV=true
 DISABLE_SETUP_PY_PROCESSING=true
+# This tests second try to install micropipenv with --isolated
+# because the first one won't work with following setting
+PIP_INDEX_URL=https://example.com/

--- a/examples/micropipenv-test-app/.s2i/environment
+++ b/examples/micropipenv-test-app/.s2i/environment
@@ -1,2 +1,5 @@
 ENABLE_MICROPIPENV=true
 DISABLE_SETUP_PY_PROCESSING=true
+# This tests second try to install micropipenv with --isolated
+# because the first one won't work with following setting
+PIP_INDEX_URL=https://example.com/

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -40,8 +40,8 @@ function install_tool() {
   # have your own PyPI mirror, it will take it from there. If this try fails, try it
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
-  $VENV_DIR/bin/pip install -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
-  if [ $? -ne 0 ]; then
+  # $1$2 combines package name with [extras] or version specifier if is defined as $2```
+  if ! $VENV_DIR/bin/pip install -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
     $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
@@ -71,11 +71,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version 19.3.1 ..."
-pip install -U "pip==19.3.1"
+if ! pip install -U "pip==19.3.1"; then
+  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip==19.3.1"
+fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST"{% if spec.version in ["2.7"] %} || ! -z "$ENABLE_PIPENV"{% endif %} ]]; then
   echo "---> Upgrading pip to latest version ..."
-  pip install -U pip setuptools wheel
+  if ! pip install -U pip setuptools wheel; then
+    echo "WARNING: Installation of the latest pip,setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
+    pip install --isolated -U pip setuptools wheel
+  fi
 fi
 
 if [[ ! -z "$ENABLE_PIPENV" ]]; then


### PR DESCRIPTION
Depends on #388 and #380 

This basically deactivates the regular `pip install micropipenv` so we test also `pip install --isolated micropipenv`.