### PR TITLE
Test the latest version in imagestreams

### DIFF
--- a/2.7/test/run
+++ b/2.7/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -187,6 +187,17 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
+
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +234,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.7/test/run
+++ b/3.7/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.8/test/run
+++ b/3.8/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/imagestreams/python-centos7.json
+++ b/imagestreams/python-centos7.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Python (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+          "description": "Build and run Python applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
           "iconClass": "icon-python",
           "tags": "builder,python",
           "supports":"python",
@@ -22,7 +22,27 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.6"
+          "name": "3.8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.8",
+        "annotations": {
+          "openshift.io/display-name": "Python 3.8",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python 3.8 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
+          "iconClass": "icon-python",
+          "tags": "builder,python",
+          "supports":"python:3.8,python",
+          "version": "3.8",
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "docker.io/centos/python-38-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/check_imagestreams.py
+++ b/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../common/check_imagestreams.py


### PR DESCRIPTION
This commit adds support for testing if the latest version is present in imagestreams.

Also, imagestream/python-centos.json is updated into the latest version.
It already exists in https://hub.docker.com/r/centos/python-38-centos7.