### PR TITLE
Test the latest version in imagestreams

### DIFF
--- a/2.7/test/check_imagestreams.py
+++ b/2.7/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../../common/check_imagestreams.py

--- a/2.7/test/run
+++ b/2.7/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.6/test/check_imagestreams.py
+++ b/3.6/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../../common/check_imagestreams.py

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.7/test/check_imagestreams.py
+++ b/3.7/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../../common/check_imagestreams.py

--- a/3.7/test/run
+++ b/3.7/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/3.8/test/check_imagestreams.py
+++ b/3.8/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../../common/check_imagestreams.py

--- a/3.8/test/run
+++ b/3.8/test/run
@@ -187,6 +187,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -223,6 +233,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}

--- a/examples/npm-virtualenv-uwsgi-test-app/app.sh
+++ b/examples/npm-virtualenv-uwsgi-test-app/app.sh
@@ -13,7 +13,7 @@ packages=("pip" "setuptools" "wheel")
 for pkg in ${packages[@]}; do
   # grep returns exit code 1 if the output contains only one line starting
   # with "Requirement already …" which means that the package is updated
-  python -m pip install -U --no-python-version-warning $pkg 2>&1 | grep -v "^Requirement already up-to-date: "
+  python -m pip install -U --no-deps --no-python-version-warning $pkg 2>&1 | grep -v "^Requirement already up-to-date: "
   if [ $? -eq 0 ]; then
     echo "ERROR: Failed to upgrade '$pkg' to the latest version."
     exit 1

--- a/manifest.sh
+++ b/manifest.sh
@@ -105,6 +105,9 @@ SYMLINK_RULES="
 
     link_target=../../imagestreams
     link_name=test/imagestreams;
+
+    link_target=../../common/check_imagestreams.py
+    link_name=test/check_imagestreams.py;
 "
 
 # Files to copy

--- a/test/check_imagestreams.py
+++ b/test/check_imagestreams.py
@@ -1,0 +1,1 @@
+../common/check_imagestreams.py

--- a/test/run
+++ b/test/run
@@ -188,6 +188,16 @@ test_application() {
   cleanup_app
 }
 
+test_latest_imagestreams() {
+  local result=1
+  info "Testing the latest version in imagestreams"
+  # Switch to root directory of a container
+  pushd "${test_dir}/../.." >/dev/null || return 1
+  ct_check_latest_imagestreams
+  result=$?
+  popd >/dev/null || return 1
+  check_result $result
+}
 
 # Since we built the candidate image locally, we don't want S2I attempt to pull
 # it from Docker hub
@@ -224,6 +234,8 @@ for app in ${@:-${WEB_APPS[@]}}; do
 
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
+
+  test_latest_imagestreams
 
   info "All tests for the ${app} finished successfully."
   cleanup ${app}


### PR DESCRIPTION
This commit adds support for testing if the latest version is present in imagestreams.

Also, imagestream/python-centos.json is updated into the latest version.
It already exists in https://hub.docker.com/r/centos/python-38-centos7.

Reworked commits from #393 mainly to address distgen issues.