### PR TITLE
Support testing s2i-python container in OpenShift 4

### DIFF
--- a/2.7/test/run-openshift-remote-cluster
+++ b/2.7/test/run-openshift-remote-cluster
@@ -1,0 +1,1 @@
+../../test/run-openshift-remote-cluster

--- a/2.7/test/test-lib-remote-openshift.sh
+++ b/2.7/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/3.6/test/run-openshift-remote-cluster
+++ b/3.6/test/run-openshift-remote-cluster
@@ -1,0 +1,1 @@
+../../test/run-openshift-remote-cluster

--- a/3.6/test/test-lib-remote-openshift.sh
+++ b/3.6/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/3.7/test/run-openshift-remote-cluster
+++ b/3.7/test/run-openshift-remote-cluster
@@ -1,0 +1,1 @@
+../../test/run-openshift-remote-cluster

--- a/3.7/test/test-lib-remote-openshift.sh
+++ b/3.7/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/3.8/test/run-openshift-remote-cluster
+++ b/3.8/test/run-openshift-remote-cluster
@@ -1,0 +1,1 @@
+../../test/run-openshift-remote-cluster

--- a/3.8/test/test-lib-remote-openshift.sh
+++ b/3.8/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/3.9/test/run-openshift-remote-cluster
+++ b/3.9/test/run-openshift-remote-cluster
@@ -1,0 +1,1 @@
+../../test/run-openshift-remote-cluster

--- a/3.9/test/test-lib-remote-openshift.sh
+++ b/3.9/test/test-lib-remote-openshift.sh
@@ -1,0 +1,1 @@
+../../common/test-lib-remote-openshift.sh

--- a/manifest.sh
+++ b/manifest.sh
@@ -100,11 +100,17 @@ SYMLINK_RULES="
     link_target=../../test/run-openshift
     link_name=test/run-openshift;
 
+    link_target=../../test/run-openshift-remote-cluster
+    link_name=test/run-openshift-remote-cluster;
+
     link_target=../../common/test-lib.sh
     link_name=test/test-lib.sh;
 
     link_target=../../common/test-lib-openshift.sh
     link_name=test/test-lib-openshift.sh;
+
+    link_target=../../common/test-lib-remote-openshift.sh
+    link_name=test/test-lib-remote-openshift.sh;
 
     link_target=../../test/test-lib-python.sh
     link_name=test/test-lib-python.sh;

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -11,8 +11,11 @@ THISDIR=$(dirname ${BASH_SOURCE[0]})
 source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
 source "${THISDIR}/test-lib-python.sh"
+source "${THISDIR}/test-lib-remote-openshift.sh"
 
 set -eo nounset
+ct_os_set_ocp4
+
 
 trap ct_os_cleanup EXIT SIGINT
 
@@ -20,9 +23,8 @@ ct_os_check_compulsory_vars
 
 oc status || false "It looks like oc is not properly logged in."
 
-export CT_SKIP_NEW_PROJECT=true
-export CT_SKIP_UPLOAD_IMAGE=true
-export CT_NAMESPACE=openshift
+# For testing on OpenShift 4 we use internal registry
+export CT_EXTERNAL_REGISTRY=true
 
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
@@ -41,8 +43,8 @@ for template in $EPHEMERAL_TEMPLATES; do
                             "$template" \
                             python \
                             'Welcome to your Django application on OpenShift' \
-                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
-                            "centos/postgresql-96-centos7|postgresql:9.6"
+                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
+                            "rhscl/postgresql-10-rhel7|postgresql:10"
 done
 
 # Check the imagestream

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -24,7 +24,7 @@ function test_python_imagestream() {
                                      'python' \
                                      'Welcome to your Django application on OpenShift' \
                                      8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
-                                     "quay.io/centos7/postgresql-10-centos7|postgresql:10"
+                                     "rhscl/postgresql-10-rhel7|postgresql:10"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This commits add support for testing s2i-python-container in OpenShift 4.

Prerequisite for green tests is to merge https://github.com/sclorg/container-common-scripts/pull/174
I have locally tested it in resalloc server and the tests are green.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>