### PR TITLE
Fix pip downgrade

### DIFF
--- a/2.7/s2i/bin/assemble
+++ b/2.7/s2i/bin/assemble
@@ -62,10 +62,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" || ! -z "$ENABLE_PIPENV" ]]; then

--- a/3.6/s2i/bin/assemble
+++ b/3.6/s2i/bin/assemble
@@ -61,10 +61,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then

--- a/3.7/s2i/bin/assemble
+++ b/3.7/s2i/bin/assemble
@@ -57,10 +57,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then

--- a/3.8/s2i/bin/assemble
+++ b/3.8/s2i/bin/assemble
@@ -57,10 +57,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then

--- a/3.9/s2i/bin/assemble
+++ b/3.9/s2i/bin/assemble
@@ -57,10 +57,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then

--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -70,10 +70,10 @@ fix-permissions /opt/app-root -P
 # * pip < 9 does not support different packages' versions for Python 2/3
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
 #   support platforms like ppc64le, aarch64 or armv7
-echo "---> Upgrading pip to version 19.3.1 ..."
-if ! pip install -U "pip==19.3.1"; then
-  echo "WARNING: Installation of 'pip==19.3.1' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip==19.3.1"
+echo "---> Upgrading pip to at least version 19.3.1 ..."
+if ! pip install -U "pip>=19.3.1"; then
+  echo "WARNING: Installation of 'pip>=19.3.1' failed, trying again from official PyPI with pip --isolated install"
+  pip install --isolated -U "pip>=19.3.1"
 fi
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST"{% if spec.version in ["2.7"] %} || ! -z "$ENABLE_PIPENV"{% endif %} ]]; then


### PR DESCRIPTION
The current implementation needs at least pip 19.3.1 to support new wheels etc. which is fine for RHEL and Centos but in Fedora, we already have a newer pip version so this change should prevent a downgrade if a newer version is already available.

@torsava could you please take a look?