### PR TITLE
Recommend ADD --chown 1001:0 syntax if possible

### DIFF
--- a/2.7/README.md
+++ b/2.7/README.md
@@ -108,10 +108,13 @@ To use the Source-to-Image scripts and build an image using a Dockerfile, create
 FROM registry.access.redhat.com/ubi8/python-27
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD app-src /tmp/src
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
 # Set the default command for the resulting image

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -108,10 +108,13 @@ To use the Source-to-Image scripts and build an image using a Dockerfile, create
 FROM registry.access.redhat.com/ubi8/python-36
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD app-src /tmp/src
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
 # Set the default command for the resulting image

--- a/3.8/README.md
+++ b/3.8/README.md
@@ -108,10 +108,13 @@ To use the Source-to-Image scripts and build an image using a Dockerfile, create
 FROM registry.access.redhat.com/ubi8/python-38
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD app-src /tmp/src
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
 # Set the default command for the resulting image

--- a/3.9/README.md
+++ b/3.9/README.md
@@ -108,10 +108,13 @@ To use the Source-to-Image scripts and build an image using a Dockerfile, create
 FROM 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD app-src /tmp/src
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
 # Set the default command for the resulting image

--- a/src/README.md
+++ b/src/README.md
@@ -108,10 +108,13 @@ To use the Source-to-Image scripts and build an image using a Dockerfile, create
 FROM {{ spec.main_image }}
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
-ADD app-src /tmp/src
-RUN chown -R 1001:0 /tmp/src
-USER 1001
+# With older docker that does not support --chown option for ADD statement,
+# use these statements instead:
+#  USER 0
+#  ADD app-src /tmp/src
+#  RUN chown -R 1001:0 /tmp/src
+#  USER 1001
+ADD --chown 1001:0 app-src /tmp/src
 # Install the dependencies
 RUN /usr/libexec/s2i/assemble
 # Set the default command for the resulting image

--- a/src/test/from-dockerfile/Dockerfile.tpl
+++ b/src/test/from-dockerfile/Dockerfile.tpl
@@ -2,6 +2,9 @@ FROM #IMAGE_NAME# # Replaced by sed in tests, see test_from_dockerfile in test/r
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
+# With a newer docker that supports --chown option for ADD statement, or with
+# podman, we can replace the following four statements with
+#   ADD --chown 1001:0 app-src /tmp/src
 USER 0
 ADD app-src /tmp/src
 RUN chown -R 1001:0 /tmp/src


### PR DESCRIPTION
Unfortunately, --chmod option was added into docker in v17, so it does not work
with docker we have in RHEL-7.

For supporting docker with our example Dockerfiles, we can use the older way,
but in README.md, where we recommend using podman (that supports the --chown option),
we can already use the newer shorter syntax that also does not need changing
USER to 0 that might be prohibitted.