### PR TITLE
imagestream: point centos7 images to quay.io

### DIFF
--- a/imagestreams/python-centos.json
+++ b/imagestreams/python-centos.json
@@ -142,7 +142,7 @@
         },
         "from": {
           "kind": "DockerImage",
-          "name": "docker.io/centos/python-27-centos7:latest"
+          "name": "quay.io/centos7/python-27-centos7:latest"
         },
         "referencePolicy": {
           "type": "Local"


### PR DESCRIPTION
Use quay.io as a source of the images to avoid Docker Hub ratelimiting where possible