### PR TITLE
Support Quay.io postgresql-10 images instead of 9.7

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -46,8 +46,8 @@ for template in $EPHEMERAL_TEMPLATES; do
                             "$template" \
                             python \
                             'Welcome to your Django application on OpenShift' \
-                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
-                            "centos/postgresql-96-centos7|postgresql:9.6"
+                            8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
+                            "quay.io/centos7/postgresql-10-centos7|postgresql:10"
 done
 
 # Check the imagestream

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -23,8 +23,8 @@ function test_python_imagestream() {
                                      "${IMAGE_NAME}" \
                                      'python' \
                                      'Welcome to your Django application on OpenShift' \
-                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=9.6 -p NAME=python-testing" \
-                                     "centos/postgresql-96-centos7|postgresql:9.6"
+                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
+                                     "quay.io/centos7/postgresql-10-centos7|postgresql:10"
 }
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:


### PR DESCRIPTION
This commit removes the dependency on images stored in DockerHub.
Instead of DockerHub we are using Quay.io.

Postgresql-9.6 image does not exist on Quay.io. It has been already deprecated.
Switching into postresql-10.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>