### PR TITLE
Run only fedora TMT tests and not cwt tests.

### DIFF
--- a/.github/workflows/centos7-openshift-tests.yaml
+++ b/.github/workflows/centos7-openshift-tests.yaml
@@ -61,7 +61,8 @@ jobs:
             "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
             "test": {"fmf": {
               "url": "https://github.com/sclorg/sclorg-testing-farm",
-              "ref": "main"
+              "ref": "main",
+              "name": "fedora"
             }},
             "environments": [{
               "arch": "x86_64",

--- a/.github/workflows/centos7-tests.yaml
+++ b/.github/workflows/centos7-tests.yaml
@@ -61,7 +61,8 @@ jobs:
             "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
             "test": {"fmf": {
               "url": "https://github.com/sclorg/sclorg-testing-farm",
-              "ref": "main"
+              "ref": "main",
+              "name": "fedora"
             }},
             "environments": [{
               "arch": "x86_64",

--- a/.github/workflows/fedora-tests.yaml
+++ b/.github/workflows/fedora-tests.yaml
@@ -60,7 +60,8 @@ jobs:
             "api_key": "${{ secrets.TF_PUBLIC_API_KEY }}",
             "test": {"fmf": {
               "url": "https://github.com/sclorg/sclorg-testing-farm",
-              "ref": "main"
+              "ref": "main",
+              "name": "fedora"
             }},
             "environments": [{
               "arch": "x86_64",


### PR DESCRIPTION
Available plans are here: https://github.com/sclorg/sclorg-testing-farm/tree/main/plans
The specification is the name without `fmf` extension.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>