### PR TITLE
Use ct pull image

### DIFF
--- a/test/run-openshift
+++ b/test/run-openshift
@@ -15,6 +15,10 @@ source "${THISDIR}/test-lib-python.sh"
 
 set -eo nounset
 
+# Pull images before test execution and exit if docker/podman pull operation failed
+ct_pull_image "registry.access.redhat.com/ubi7/ubi" "true"
+ct_pull_image "registry.access.redhat.com/rhscl/postgresql-10-rhel7" "true"
+
 trap ct_os_cleanup EXIT SIGINT
 
 test_latest_imagestreams() {

--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -14,8 +14,12 @@ source "${THISDIR}/test-lib-python.sh"
 source "${THISDIR}/test-lib-remote-openshift.sh"
 
 set -eo nounset
-ct_os_set_ocp4
 
+# Pull images before test execution and exit if docker/podman pull operation failed
+ct_pull_image "registry.access.redhat.com/ubi7/ubi" "true"
+ct_pull_image "registry.access.redhat.com/rhscl/postgresql-10-rhel7" "true"
+
+ct_os_set_ocp4
 
 trap ct_os_cleanup EXIT SIGINT
 


### PR DESCRIPTION
Before any OpenShift 3,4 tests execution, let's try to pull images.
If the images are not pullable, then failed, because the OpenShift 3,4 tests will fail too.