### PR TITLE
add pip extra args

### DIFF
--- a/src/s2i/bin/assemble
+++ b/src/s2i/bin/assemble
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+pip_install_args=${PIP_INSTALL_ARGS:-}
+if [ ! -z "$PIP_CACHE_DIR" ]; then
+  pip_install_args="$pip_install_args --cache-dir $PIP_CACHE_DIR"
+fi
+
 function is_django_installed() {
   python -c "import django" &>/dev/null
 }
@@ -32,7 +37,7 @@ function virtualenv_bin() {
 function install_tool() {
   echo "---> Installing $1 packaging tool ..."
   {% if spec.version in ["2.7"] %}
-  pip install -U virtualenv
+  pip install $pip_install_args -U virtualenv
   {% endif %}
   VENV_DIR=$HOME/.local/venvs/$1
   virtualenv_bin "$VENV_DIR"
@@ -41,9 +46,9 @@ function install_tool() {
   # again with --isolated which ignores external pip settings (env vars, config file)
   # and installs the tool from PyPI (needs internet connetion).
   # $1$2 combines package name with [extras] or version specifier if is defined as $2```
-  if ! $VENV_DIR/bin/pip install -U $1$2; then
+  if ! $VENV_DIR/bin/pip install $pip_install_args -U $1$2; then
     echo "WARNING: Installation of $1 failed, trying again from official PyPI with pip --isolated install"
-    $VENV_DIR/bin/pip install --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
+    $VENV_DIR/bin/pip install $pip_install_args --isolated -U $1$2  # Combines package name with [extras] or version specifier if is defined as $2```
   fi
   mkdir -p $HOME/.local/bin
   ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
@@ -73,17 +78,17 @@ fix-permissions /opt/app-root -P
 # * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 (and later) wheels
 #   support platforms like ppc64le, aarch64 or armv7
 echo "---> Upgrading pip to version <21.0 (The last Python 2 compatible version) ..."
-if ! pip install -U "pip<21.0"; then
+if ! pip install $pip_install_args -U "pip<21.0"; then
   echo "WARNING: Installation of 'pip<21.0' failed, trying again from official PyPI with pip --isolated install"
-  pip install --isolated -U "pip<21.0"
+  pip install $pip_install_args --isolated -U "pip<21.0"
 fi
 {% endif %}
 
 if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
   echo "---> Upgrading pip, setuptools and wheel to latest version ..."
-  if ! pip install -U pip setuptools wheel; then
+  if ! pip install $pip_install_args -U pip setuptools wheel; then
     echo "WARNING: Installation of the latest pip, setuptools and wheel failed, trying again from official PyPI with pip --isolated install"
-    pip install --isolated -U pip setuptools wheel
+    pip install $pip_install_args --isolated -U pip setuptools wheel
   fi
 fi
 
@@ -107,12 +112,12 @@ elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
   micropipenv install --deploy
 elif [[ -f requirements.txt ]]; then
   echo "---> Installing dependencies ..."
-  pip install -r requirements.txt
+  pip install $pip_install_args -r requirements.txt
 fi
 
 if [[ ( -f setup.py || -f setup.cfg ) && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
   echo "---> Installing application ..."
-  pip install .
+  pip install $pip_install_args .
 fi
 
 if should_collectstatic; then

--- a/src/s2i/bin/run
+++ b/src/s2i/bin/run
@@ -116,12 +116,15 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="default"
     else
       gunicorn_settings_source="custom"
+      if [ ! -z "$APP_CONFIG" ];then
+        GUNICORN_CMD_ARGS="$GUNICORN_CMD_ARGS --config $APP_CONFIG"
+      fi
     fi
 
     # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
     # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
-    exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
+    exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS
   fi
 fi
 


### PR DESCRIPTION
Pip cache is disabled by default in s2i image, this setting allows to override this. Useful when building with Buildah:

```bash
ctr=$(buildah from registry.redhat.io/ubi8/python-38:latest)
mnt=$(buildah unshare buildah mount $ctr)
#host cache folder
mkdir ~/.cache/pip -p
[ -d $mnt/.pip-cache ] && rm $mnt/.pip-cache
#link from container  to host folder
ln -s ~/.cache/pip $mnt/.pip-cache
buildah config --env PIP_CACHE_DIR=/.pip-cache $ctr
buildah unshare buildah run --user 0 $ctr -- /usr/libexec/s2i/assemble
buildah unmount $ctr
buildah commit $ctr my-app
```
