### PR TITLE
Schedule CentOS Stream 9 tests in Testing Farm

### DIFF
--- a/.github/workflows/docker-tests.yml
+++ b/.github/workflows/docker-tests.yml
@@ -37,6 +37,12 @@ jobs:
             compose: "RHEL-8.3.1-Released"
             tmt_url: "http://artifacts.osci.redhat.com/testing-farm/"
             tmt_repo: "https://gitlab.cee.redhat.com/platform-eng-core-services/sclorg-tmt-plans"
+          - tmt_plan: "c9s"
+            os_test: "c9s"
+            context: "CentOS Stream 9"
+            compose: "CentOS-Stream-9"
+            tmt_url: "http://artifacts.dev.testing-farm.io"
+            tmt_repo: "https://github.com/sclorg/sclorg-testing-farm"
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))


### PR DESCRIPTION
This pull request adds only support for scheduling
tests in Testing Farm. The alone changes
regarding building, testing, and push will be
as a separate pull request.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>