### PR TITLE
Newer Fedora with older Pythons

### DIFF
--- a/3.9/Dockerfile.fedora
+++ b/3.9/Dockerfile.fedora
@@ -1,6 +1,6 @@
 # This image provides a Python 3.9 environment you can use to run your Python
 # applications.
-FROM quay.io/fedora/s2i-base:34
+FROM quay.io/fedora/s2i-base:35
 
 EXPOSE 8080
 
@@ -38,9 +38,8 @@ LABEL summary="$SUMMARY" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.9/test/setup-test-app/ quay.io/fedora/$NAME-39 python-sample-app" \
       maintainer="SoftwareCollections.org <sclorg@redhat.com>"
 
-RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip nss_wrapper \
-        httpd httpd-devel atlas-devel gcc-gfortran libffi-devel \
-        libtool-ltdl enchant redhat-rpm-config" && \
+RUN INSTALL_PKGS="python3.9 nss_wrapper httpd httpd-devel atlas-devel \
+        gcc-gfortran libffi-devel libtool-ltdl enchant redhat-rpm-config" && \
     dnf -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     dnf -y clean all --enablerepo='*'

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -78,9 +78,11 @@ specs:
       fedora_version: "35"
       s2i_base: quay.io/fedora/s2i-base
       img_tag: "35"
-      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
       base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'atlas-devel', 'gcc-gfortran',
                   'libffi-devel', 'libtool-ltdl enchant', 'redhat-rpm-config']
+      extra_pkgs:
+        "3.9": ['python{{ spec.version }}']
+        "default": ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
 
   version:
     "3.10":
@@ -155,7 +157,6 @@ matrix:
         - centos-stream-9-x86_64
       version: "3.8"
     - distros:
-        - fedora-35-x86_64
         - centos-7-x86_64
         - rhel-7-x86_64
       version: "3.9"

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -72,16 +72,6 @@ specs:
                   'mod_auth_gssapi', 'mod_ldap', 'mod_session',
                   'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
 
-    fedora34:
-      distros:
-        - fedora-34-x86_64
-      fedora_version: "34"
-      s2i_base: quay.io/fedora/s2i-base
-      img_tag: "34"
-      python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
-      base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'atlas-devel', 'gcc-gfortran',
-                  'libffi-devel', 'libtool-ltdl enchant', 'redhat-rpm-config']
-
     fedora35:
       distros:
         - fedora-35-x86_64
@@ -144,12 +134,10 @@ specs:
 matrix:
   exclude:
     - distros:
-        - fedora-34-x86_64
         - fedora-35-x86_64
         - centos-stream-9-x86_64
       version: "2.7"
     - distros:
-        - fedora-34-x86_64
         - fedora-35-x86_64
         - centos-7-x86_64
         - rhel-7-x86_64
@@ -157,14 +145,12 @@ matrix:
       version: "3.6"
     - distros:
         - centos-7-x86_64
-        - fedora-34-x86_64
         - fedora-35-x86_64
         - rhel-7-x86_64
         - rhel-8-x86_64
         - centos-stream-9-x86_64
       version: "3.7"
     - distros:
-        - fedora-34-x86_64
         - fedora-35-x86_64
         - centos-stream-9-x86_64
       version: "3.8"
@@ -174,7 +160,6 @@ matrix:
         - rhel-7-x86_64
       version: "3.9"
     - distros:
-        - fedora-34-x86_64
         - centos-7-x86_64
         - rhel-7-x86_64
         - rhel-8-x86_64

--- a/src/Dockerfile.template
+++ b/src/Dockerfile.template
@@ -73,7 +73,7 @@ LABEL summary="$SUMMARY" \
 {% else %}
     {% set extra_pkgs = [] %}
 {% endif %}
-RUN INSTALL_PKGS="{{ common.list_pkgs(extra_pkgs + spec.python_pkgs + spec.base_pkgs) -}}
+RUN INSTALL_PKGS="{{ common.list_pkgs(extra_pkgs + spec.get('python_pkgs', []) + spec.base_pkgs) -}}
     {% if spec.preinstall_cmd %}
 {{ common.preinstall_cmd(spec) -}}
     {% endif %}


### PR DESCRIPTION
I've realized that because we maintain older Pythons in all Fedora releases, there is no reason to use only combinations of Fedora and the main python3 package in every release. We can always use the latest stable Fedora and whatever python3.X package is available in it.

I'm using it to switch Python 3.9 from Fedora 34 which will soon be EOL to Fedora 35 but we can also restore even older Pythons without worrying about what happens during the next Fedora update (soon 35 → 36).

Do you see any problem with this approach?

Cc: @torsava @hroncok 