### PR TITLE
make s2i-python use generic function for running container tests

### DIFF
--- a/2.7/test/run
+++ b/2.7/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -245,9 +247,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -257,28 +257,6 @@ test_scl_variables_in_dockerfile() {
      ct_check_scl_enable_vars
      check_result $?
   fi
-}
-
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
 }
 
 # For debugging purposes, this script can be run with one or more arguments
@@ -312,19 +290,10 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
 
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT

--- a/3.10/test/run
+++ b/3.10/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -245,9 +247,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -257,28 +257,6 @@ test_scl_variables_in_dockerfile() {
      ct_check_scl_enable_vars
      check_result $?
   fi
-}
-
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
 }
 
 # For debugging purposes, this script can be run with one or more arguments
@@ -312,19 +290,10 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
 
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -245,9 +247,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -257,28 +257,6 @@ test_scl_variables_in_dockerfile() {
      ct_check_scl_enable_vars
      check_result $?
   fi
-}
-
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
 }
 
 # For debugging purposes, this script can be run with one or more arguments
@@ -312,19 +290,10 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
 
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT

--- a/3.8/test/run
+++ b/3.8/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -245,9 +247,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -257,28 +257,6 @@ test_scl_variables_in_dockerfile() {
      ct_check_scl_enable_vars
      check_result $?
   fi
-}
-
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
 }
 
 # For debugging purposes, this script can be run with one or more arguments
@@ -312,19 +290,10 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
 
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT

--- a/3.9/test/run
+++ b/3.9/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -245,9 +247,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -257,28 +257,6 @@ test_scl_variables_in_dockerfile() {
      ct_check_scl_enable_vars
      check_result $?
   fi
-}
-
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
 }
 
 # For debugging purposes, this script can be run with one or more arguments
@@ -312,19 +290,10 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
 
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT

--- a/test/run
+++ b/test/run
@@ -37,6 +37,8 @@ IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
 
 . test/test-lib.sh
 
+ct_enable_cleanup
+
 info() {
   echo -e "\n\e[1m[INFO] $@\e[0m\n"
 }
@@ -247,9 +249,7 @@ test_application_enable_init_wrapper() {
 test_scl_variables_in_dockerfile() {
   if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
      TESTCASE_RESULT=0
-     # autocleanup only enabled here as only the following tests so far use it
      CID_FILE_DIR=$(mktemp -d)
-     ct_enable_cleanup
 
      info "Testing variable presence during \`docker exec\`"
      ct_check_exec_env_vars
@@ -298,3 +298,4 @@ for app in ${@:-${WEB_APPS[@]}}; do
 done
 
 TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"
+

--- a/test/run
+++ b/test/run
@@ -261,28 +261,6 @@ test_scl_variables_in_dockerfile() {
   fi
 }
 
-function run_all_tests() {
-  local APP_NAME=${1:-undefined}
-  for test_case in $TEST_SET; do
-    info "Running test $test_case ... "
-    TESTCASE_RESULT=0
-    $test_case
-    local test_msg
-    if [ $TESTCASE_RESULT -eq 0 ]; then
-      test_msg="[PASSED]"
-    else
-      test_msg="[FAILED]"
-      TESTSUITE_RESULT=1
-    fi
-    test "$APP_NAME" == "undefined" && msg_app="" || msg_app="'$APP_NAME'"
-    printf -v test_short_summary "%s %s for %s %s\n" "${test_short_summary}" "${test_msg}" "${msg_app}" "$test_case"
-    [ -n "${FAIL_QUICKLY:-}" ] && {
-      cleanup "${APP_NAME}"
-      return 1
-    }
-  done;
-}
-
 # For debugging purposes, this script can be run with one or more arguments
 # those arguments list is a sub-set of values in the WEB_APPS array defined above
 # Example: ./run app-home-test-app pipenv-test-app
@@ -314,19 +292,9 @@ for app in ${@:-${WEB_APPS[@]}}; do
     printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
   fi
   echo ""
-  TEST_SET=${TESTS:-$TEST_LIST} run_all_tests "${app}"
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"
 
   cleanup ${app}
 done
 
-TEST_SET=${TESTS:-$TEST_VAR_DOCKER} run_all_tests
-
-echo "$test_short_summary"
-
-if [ $TESTSUITE_RESULT -eq 0 ] ; then
-  echo "Tests for ${IMAGE_NAME} succeeded."
-else
-  echo "Tests for ${IMAGE_NAME} failed."
-fi
-
-exit $TESTSUITE_RESULT
+TEST_SET=${TESTS:-$TEST_VAR_DOCKER} ct_run_tests_from_testset "var-docker"


### PR DESCRIPTION
This PR also needs support in common/ because of printing the results (preferably in the `ct_cleanup` function).