### PR TITLE
Remove RHEL 7 Python 2.7 imagestreams

### DIFF
--- a/imagestreams/python-centos.json
+++ b/imagestreams/python-centos.json
@@ -147,46 +147,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "2.7-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Python 2.7 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 2.7 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python",
-          "supports":"python:2.7,python",
-          "version": "2.7",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/python-27:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.7",
-        "annotations": {
-          "openshift.io/display-name": "Python 2.7",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 2.7 applications on CentOS 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python,hidden",
-          "supports":"python:2.7,python",
-          "version": "2.7",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "quay.io/centos7/python-27-centos7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }

--- a/imagestreams/python-rhel.json
+++ b/imagestreams/python-rhel.json
@@ -167,46 +167,6 @@
         "referencePolicy": {
           "type": "Local"
         }
-      },
-      {
-        "name": "2.7-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Python 2.7 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 2.7 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python",
-          "supports":"python:2.7,python",
-          "version": "2.7",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/python-27:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "2.7",
-        "annotations": {
-          "openshift.io/display-name": "Python 2.7",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 2.7 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python,hidden",
-          "supports":"python:2.7,python",
-          "version": "2.7",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/python-27-rhel7:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
       }
     ]
   }


### PR DESCRIPTION
RHEL 7 Python 2.7 retirement: July 2022

https://access.redhat.com/support/policy/updates/rhscl-rhel7

/cc @hhorak
