### PR TITLE
Exit oc4  tests if login fails

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -20,7 +20,6 @@ test_python_imagestream
 test_python_s2i_templates
 "
 
-set -u
 # Pull image before going throw tests
 # Exit in case of failure
 ct_pull_image "quay.io/centos7/postgresql-10-centos7" "true"
@@ -31,7 +30,9 @@ trap ct_os_cleanup EXIT SIGINT
 
 ct_os_check_compulsory_vars
 
-oc status || false "It looks like oc is not properly logged in."
+ct_os_check_login || exit 1
+
+set -u
 
 # For testing on OpenShift 4 we use internal registry
 export CT_OCP4_TEST=true


### PR DESCRIPTION
The nounset shell option needs to be set after the OC login attempt,
because (from man shopt):
```
-u
  If expansion is attempted on an unset  variable  or
  parameter,  the  shell prints  an  error  message, and, if not
  interactive exits with a non-zero status.
```
That is in this matter inconvenient, as we do not really know from the logs
what has happened if the oc login fails and moreover the test suite ends
with success, as only the first failed test sets TESTSUITE_RESULT to 1.
If we check login with the ct_os_check_login function, it handles the
situation conveniently.