### PR TITLE
Test installation and import of pyenchant package

### DIFF
--- a/3.9-minimal/test/from-dockerfile/mod_wsgi.Dockerfile.tpl
+++ b/3.9-minimal/test/from-dockerfile/mod_wsgi.Dockerfile.tpl
@@ -19,9 +19,9 @@ from #IMAGE_NAME#
 # Copy app sources together with the whole virtual environment from the builder image
 COPY --from=builder $APP_ROOT $APP_ROOT
 
-# Install httpd package - runtime dependency of our application
+# Install httpd and echant packages - runtime dependencies of our application
 USER 0
-RUN microdnf install -y httpd
+RUN microdnf install -y httpd enchant
 USER 1001
 
 # Set the default command for the resulting image

--- a/3.9/Dockerfile.rhel9
+++ b/3.9/Dockerfile.rhel9
@@ -40,7 +40,7 @@ LABEL summary="$SUMMARY" \
 
 RUN INSTALL_PKGS="python3 python3-devel python3-setuptools python3-pip nss_wrapper \
         httpd httpd-devel mod_ssl mod_auth_gssapi mod_ldap \
-        mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl" && \
+        mod_session atlas-devel gcc-gfortran libffi-devel libtool-ltdl enchant" && \
     yum -y --setopt=tsflags=nodocs install $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     # Remove redhat-logos-httpd (httpd dependency) to keep image size smaller.

--- a/examples/micropipenv-requirements-test-app/requirements.txt
+++ b/examples/micropipenv-requirements-test-app/requirements.txt
@@ -1,2 +1,4 @@
 mod_wsgi
 Flask
+# Tests that the pyenchant package is installable
+pyenchant

--- a/examples/micropipenv-requirements-test-app/wsgi.py
+++ b/examples/micropipenv-requirements-test-app/wsgi.py
@@ -1,3 +1,4 @@
+import enchant
 from flask import Flask
 application = Flask(__name__)
 

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -71,7 +71,7 @@ specs:
       python_pkgs: ['python3', 'python3-devel', 'python3-setuptools', 'python3-pip']
       base_pkgs: ['nss_wrapper', 'httpd', 'httpd-devel', 'mod_ssl',
                   'mod_auth_gssapi', 'mod_ldap', 'mod_session',
-                  'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl']
+                  'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl enchant']
       ubi_versions: ['3.9']
 
     c9s:


### PR DESCRIPTION
enchant RPM should always be installed to support pyenchant Python wrapper. The package is not available in UBI 9 repos so this test has to wait for it.