### PR TITLE
Set VIRTUAL_ENV in venv_setup

### DIFF
--- a/2.7/Dockerfile.rhel8
+++ b/2.7/Dockerfile.rhel8
@@ -72,6 +72,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.10/Dockerfile.fedora
+++ b/3.10/Dockerfile.fedora
@@ -81,6 +81,7 @@ fix-permissions ${APP_ROOT} -P
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.6/Dockerfile.rhel8
+++ b/3.6/Dockerfile.rhel8
@@ -72,6 +72,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.8/Dockerfile.rhel8
+++ b/3.8/Dockerfile.rhel8
@@ -87,6 +87,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.9/Dockerfile.c9s
+++ b/3.9/Dockerfile.c9s
@@ -81,6 +81,7 @@ fix-permissions ${APP_ROOT} -P
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.9/Dockerfile.rhel8
+++ b/3.9/Dockerfile.rhel8
@@ -87,6 +87,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/3.9/Dockerfile.rhel9
+++ b/3.9/Dockerfile.rhel9
@@ -86,6 +86,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 USER 1001

--- a/src/centos-stream/macros.tpl
+++ b/src/centos-stream/macros.tpl
@@ -40,5 +40,6 @@ fix-permissions ${APP_ROOT} -P
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 {% endmacro %}

--- a/src/centos/macros.tpl
+++ b/src/centos/macros.tpl
@@ -64,6 +64,7 @@ RUN \
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 {% endif %}
 {% endmacro %}

--- a/src/fedora/macros.tpl
+++ b/src/fedora/macros.tpl
@@ -36,5 +36,6 @@ fix-permissions ${APP_ROOT} -P
 # so virtualenv needs to be activated this way
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
+    VIRTUAL_ENV="${APP_ROOT}" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 {% endmacro %}


### PR DESCRIPTION
If poetry is used to install dependencies in a Dockerfile, it will not obey the virtualenv set up in the container because it does not detect it properly. The dependencies end up installed into the system python paths (eg. /usr/local/lib/python3.10/site-packages/).

This shows differing behaviour to pip which if used in the Dockerfile to install dependencies will install them correctly into the virtual env path (eg. /opt/app-root/lib/python3.10/site-packages/).

Setting VIRTUAL_ENV manually in the Dockerfile gives Poetry the needed info to obey the virtual env paths.