### PR TITLE
3.9-minimal imagestream is not tested on OpenShift 4

### DIFF
--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -34,6 +34,9 @@ function test_python_imagestream() {
   elif [ "${OS}" == "rhel9" ]; then
     tag="-ubi9"
   fi
+  if [[ "${VERSION}" == *"minimal"* ]]; then
+    VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
+  fi
   ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/python-${OS%[0-9]*}.json" \
                                      'https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json' \
                                      "${IMAGE_NAME}" \

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -28,10 +28,6 @@ function ct_pull_or_import_postgresql() {
 
 # Check the imagestream
 function test_python_imagestream() {
-  case ${OS} in
-    rhel7|centos7|rhel8|rhel9) ;;
-    *) echo "Imagestream testing not supported for $OS environment." ; return 0 ;;
-  esac
   local tag="-ubi7"
   if [ "${OS}" == "rhel8" ]; then
     tag="-ubi8"


### PR DESCRIPTION
Traceback caught by Nightly Build testing.

Image version 3.9-minimal is not tested on OpenShift 4.
Use version 3.9 only.

```bash

Creating a new-app with name python in namespace sclorg-test-4456 with args -p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=3.9-minimal-ubi8 -p POSTGRESQL_VERSION=10 -p NAME=python-testing -p NAMESPACE=sclorg-test-4456.
warning: Template parameter "NAMESPACE" was overwritten
W1027 06:16:10.578503  131429 shim_kubectl.go:58] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource

[snipped]
In project sclorg-test-4456 on server https://api.core-serv-ocp.hosted.psi.rdu2.redhat.com:6443

svc/postgresql - 172.30.32.240:5432
  dc/postgresql deploys istag/postgresql:10 
    deployment #1 deployed 5 minutes ago - 1 pod

http://python-testing-sclorg-test-4456.apps.core-serv-ocp.hosted.psi.rdu2.redhat.com (svc/python-testing)
  dc/python-testing deploys istag/python-testing:latest <-
    bc/python-testing source builds https://github.com/sclorg/django-ex.git#master on istag/python:3.9-minimal-ubi8 
      not built yet
    deployment #1 waiting on image or update

Warnings:
  * bc/python-testing builds from istag/python:3.9-minimal-ubi8, but the image stream tag does not exist.
    try: istag/python:3.9-minimal-ubi8 needs to be imported.
  * The image trigger for dc/python-testing will have no effect until istag/python-testing:latest is imported or created by a build.
  * istag/python-testing:latest needs to be imported or created by a build.
    try: oc start-build python-testing
```

Let's test imagestream on version 3.9 instead of 3.9-minimal.