### PR TITLE
fail tests for specific app when prep. fails

### DIFF
--- a/2.7/test/run
+++ b/2.7/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.10/test/run
+++ b/3.10/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.11/test/run
+++ b/3.11/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.8/test/run
+++ b/3.8/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.9-minimal/test/run
+++ b/3.9-minimal/test/run
@@ -299,19 +299,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/3.9/test/run
+++ b/3.9/test/run
@@ -303,19 +303,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"

--- a/test/run
+++ b/test/run
@@ -312,19 +312,23 @@ for app in ${@:-${WEB_APPS[@]}}; do
   fi
 
   prepare ${app}
+  if [ $? -ne 0 ]; then
+    ct_update_test_result "[FAILED]" "${app}" "preparation"
+    TESTSUITE_RESULT=1
+    continue
+  fi
   run_s2i_build ${app}
   RESULT=$?
-  msg_run_s2i_build="'${app}' run_s2i_build"
   if [[ "$app" == *"-should-fail-"* ]]; then
     # Tests with '-should-fail-' in their name should fail during a build, expecting non-zero exit status
     check_type $RESULT "negative"
     test "$?" == "0" && test_msg="[PASSED]" || test_msg="[FAILED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
     continue
   else
     check_type $RESULT
     test "$?" != "0"  && test_msg="[FAILED]" || test_msg="[PASSED]"
-    printf -v test_short_summary "%s %s for %s\n" "${test_short_summary}" "$test_msg" "$msg_run_s2i_build"
+    ct_update_test_result "$test_msg" "$app" run_s2i_build
   fi
   echo ""
   TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "${app}"


### PR DESCRIPTION
Fixes: https://github.com/sclorg/s2i-python-container/issues/593

Depends on: https://github.com/sclorg/container-common-scripts/pull/338

Also I have a question. Could it make sense to have the test/run files generated by distgen only as symlinks?