### PR TITLE
Make npm-virtualenv-uwsgi-test-app compatible with mkdirp 3.0.0

### DIFF
--- a/examples/npm-virtualenv-uwsgi-test-app/app.sh
+++ b/examples/npm-virtualenv-uwsgi-test-app/app.sh
@@ -38,7 +38,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Use the mkdirp module to create a directory and it's subdirectory
-node -e "var mkdirp = require('mkdirp'); mkdirp('dir1/dir2')"
+node -e "const { mkdirp } = require('mkdirp'); mkdirp('dir1/dir2')"
 if [ $? -ne 0 ]; then
     echo "ERROR: Nodejs cannot use the freshly installed 'mkdirp' module."
     exit 1


### PR DESCRIPTION
mkdirp 3.0.0 has no default exports any more
https://github.com/isaacs/node-mkdirp/blob/main/CHANGELOG.md#30