### PR TITLE
Add support for Python-311 imagestreams

### DIFF
--- a/imagestreams/python-rhel.json
+++ b/imagestreams/python-rhel.json
@@ -14,7 +14,7 @@
         "annotations": {
           "openshift.io/display-name": "Python (Latest)",
           "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.9/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
+          "description": "Build and run Python applications on UBI. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major version updates.",
           "iconClass": "icon-python",
           "tags": "builder,python",
           "supports":"python",
@@ -22,7 +22,47 @@
         },
         "from": {
           "kind": "ImageStreamTag",
-          "name": "3.9-ubi8"
+          "name": "3.11-ubi8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.11-ubi9",
+        "annotations": {
+          "openshift.io/display-name": "Python 3.11 (UBI 9)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python 3.11 applications on UBI 9. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
+          "iconClass": "icon-python",
+          "tags": "builder,python",
+          "supports":"python:3.11,python",
+          "version": "3.11",
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi9/python-311:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "3.11-ubi8",
+        "annotations": {
+          "openshift.io/display-name": "Python 3.11 (UBI 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "Build and run Python 3.11 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.11/README.md.",
+          "iconClass": "icon-python",
+          "tags": "builder,python",
+          "supports":"python:3.11,python",
+          "version": "3.11",
+          "sampleRepo": "https://github.com/sclorg/django-ex.git"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/ubi8/python-311:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -90,6 +90,13 @@ function test_python_s2i_templates() {
 https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json \
 https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/django-postgresql.json"
   fi
+  if [[ "${VERSION}" == "3.11" ]]; then
+    postgresql_image="quay.io/sclorg/postgresql-12-c8s|postgresql:12"
+    postgresql_version="12"
+  else
+    postgresql_image="quay.io/centos7/postgresql-10-centos7|postgresql:10"
+    postgresql_version="10"
+  fi
   for template in $EPHEMERAL_TEMPLATES; do
       if [[ ${VERSION} == "2.7" ]] || docker inspect ${IMAGE_NAME} --format "{{.Config.Env}}" | tr " " "\n" | grep -q "^PLATFORM=el7"; then
         branch="master"
@@ -100,8 +107,8 @@ https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/d
                               "$template" \
                               python \
                               'Welcome to your Django application on OpenShift' \
-                              8080 http 200 "-p SOURCE_REPOSITORY_REF=$branch -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
-                              "quay.io/centos7/postgresql-10-centos7|postgresql:10"
+                              8080 http 200 "-p SOURCE_REPOSITORY_REF=$branch -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=${postgresql_version} -p NAME=python-testing" \
+                              "${postgresql_image}"
   done
 }
 

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -12,17 +12,26 @@ source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
 
 function ct_pull_or_import_postgresql() {
+  if [[ "${VERSION}" == "3.11" ]]; then
+    postgresql_image="quay.io/sclorg/postgresql-12-c8s"
+    image_short="postgresql:12"
+    image_tag="${image_short}"
+  else
+    postgresql_image="quay.io/centos7/postgresql-10-centos7"
+    image_short="postgresql:10-centos7"
+    image_tag="postgresql:10"
+  fi
   # Variable CVP is set by CVP pipeline
   if [ "${CVP:-0}" -eq "0" ]; then
     # In case of container or OpenShift 4 tests
     # Pull image before going through tests
     # Exit in case of failure, because postgresql container is mandatory
-    ct_pull_image "quay.io/centos7/postgresql-10-centos7" "true"
+    ct_pull_image "${postgresql_image}" "true"
   else
     # Import postgresql-10-centos7 image before running tests on CVP
-    oc import-image "postgresql-10-centos7:latest" --from="quay.io/centos7/postgresql-10-centos7:latest" --insecure=true --confirm
+    oc import-image "${image_short}:latest" --from="${postgresql_image}:latest" --insecure=true --confirm
     # Tag postgresql image to "postgresql:10" which is expected by test suite
-    oc tag "postgresql-10-centos7:latest" "postgresql:10"
+    oc tag "${image_short}:latest" "${image_tag}"
   fi
 }
 
@@ -37,20 +46,31 @@ function test_python_imagestream() {
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
   fi
+  if [[ "${VERSION}" == "3.11" ]]; then
+    branch="4.2.x"
+    postgresql_image="quay.io/sclorg/postgresql-12-c8s|postgresql:12"
+    postgresql_version="12"
+  else
+    branch="master"
+    postgresql_image="quay.io/centos7/postgresql-10-centos7|postgresql:10"
+    postgresql_version="10"
+  fi
   ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/python-${OS%[0-9]*}.json" \
-                                     'https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json' \
+                                     "https://raw.githubusercontent.com/sclorg/django-ex/${branch}/openshift/templates/django-postgresql.json" \
                                      "${IMAGE_NAME}" \
                                      'python' \
                                      'Welcome to your Django application on OpenShift' \
-                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=master -p PYTHON_VERSION=${VERSION}${tag} -p POSTGRESQL_VERSION=10 -p NAME=python-testing" \
-                                     "quay.io/centos7/postgresql-10-centos7|postgresql:10"
+                                     8080 http 200 "-p SOURCE_REPOSITORY_REF=$branch -p PYTHON_VERSION=${VERSION}${tag} -p POSTGRESQL_VERSION=${postgresql_version} -p NAME=python-testing" \
+                                     "$postgresql_image"
 }
+
 function test_python_s2i_app_ex_standalone() {
   ct_os_test_s2i_app "${IMAGE_NAME}" \
         "https://github.com/sclorg/s2i-python-container.git" \
         "examples/standalone-test-app" \
         "Hello World from standalone WSGI application!"
 }
+
 function test_python_s2i_app_ex() {
   if [[ ${VERSION} == "2.7" ]] || docker inspect ${IMAGE_NAME} --format "{{.Config.Env}}" | tr " " "\n" | grep -q "^PLATFORM=el7"; then
     django_example_repo_url="https://github.com/sclorg/django-ex.git"


### PR DESCRIPTION
Add support for Python-311 imagestreams.

The Python-3.11 container has reached GA so let's add test for it as well.
