### PR TITLE
Allow testing python-311 minimal in testing Farm

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "2.7", "3.8", "3.9", "3.9-minimal", "3.11" ]
+        version: [ "2.7", "3.8", "3.9", "3.9-minimal", "3.11", "3.11-minimal" ]
         os_test: [ "fedora", "rhel7", "rhel8", "rhel9", "c8s", "c9s" ]
         test_case: [ "container" ]
     if: |


### PR DESCRIPTION
Allow testing python-311 minimal in testing Farm

Alone Python 3.11 minimal container image
will be part of separate PR

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
