### PR TITLE
Migration from DeploymentConfig to Deployment

### DIFF
--- a/examples/django-postgresql-persistent.json
+++ b/examples/django-postgresql-persistent.json
@@ -142,40 +142,25 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
           "description": "Defines how to deploy the application server",
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {
         "strategy": {
           "type": "Recreate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "django-psql-persistent"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${NAME}:latest"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${NAME}"
+          "matchLabels": {
+            "name": "${NAME}"
+          }
         },
         "template": {
           "metadata": {
@@ -306,41 +291,25 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "description": "Defines how to deploy the database",
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {
         "strategy": {
           "type": "Recreate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "postgresql"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "namespace": "${NAMESPACE}",
-                "name": "postgresql:9.5"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${DATABASE_SERVICE_NAME}"
+          "matchLabels":{
+            "name": "${DATABASE_SERVICE_NAME}"
+          }
         },
         "template": {
           "metadata": {

--- a/examples/django-postgresql.json
+++ b/examples/django-postgresql.json
@@ -142,40 +142,26 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${NAME}",
         "annotations": {
           "description": "Defines how to deploy the application server",
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"${NAME}:latest\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
+
         }
       },
       "spec": {
         "strategy": {
           "type": "Recreate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "django-psql-example"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "name": "${NAME}:latest"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${NAME}"
+          "matchLabels": {
+            "name": "${NAME}"
+          }
         },
         "template": {
           "metadata": {
@@ -289,41 +275,25 @@
       }
     },
     {
-      "kind": "DeploymentConfig",
-      "apiVersion": "apps.openshift.io/v1",
+      "kind": "Deployment",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${DATABASE_SERVICE_NAME}",
         "annotations": {
           "description": "Defines how to deploy the database",
-          "template.alpha.openshift.io/wait-for-ready": "true"
+          "template.alpha.openshift.io/wait-for-ready": "true",
+          "image.openshift.io/triggers": "[{\"from\":{\"kind\":\"ImageStreamTag\",\"name\":\"postgresql:12\"},\"fieldPath\": \"spec.template.spec.containers[0].image\"}]"
         }
       },
       "spec": {
         "strategy": {
           "type": "Recreate"
         },
-        "triggers": [
-          {
-            "type": "ImageChange",
-            "imageChangeParams": {
-              "automatic": true,
-              "containerNames": [
-                "postgresql"
-              ],
-              "from": {
-                "kind": "ImageStreamTag",
-                "namespace": "${NAMESPACE}",
-                "name": "postgresql:9.5"
-              }
-            }
-          },
-          {
-            "type": "ConfigChange"
-          }
-        ],
         "replicas": 1,
         "selector": {
-          "name": "${DATABASE_SERVICE_NAME}"
+          "matchLabels":{
+            "name": "${DATABASE_SERVICE_NAME}"
+          }
         },
         "template": {
           "metadata": {

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -58,13 +58,18 @@ function test_python_imagestream() {
     postgresql_image="quay.io/centos7/postgresql-10-centos7|postgresql:10"
     postgresql_version="10"
   fi
-  ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/python-${OS%[0-9]*}.json" \
-                                     "https://raw.githubusercontent.com/sclorg/django-ex/${branch}/openshift/templates/django-postgresql.json" \
+  TEMPLATES="
+django-postgresql.json \
+django-postgresql-persistent.json"
+  for template in $TEMPLATES; do
+    ct_os_test_image_stream_quickstart "${THISDIR}/imagestreams/python-${OS%[0-9]*}.json" \
+                                     "https://raw.githubusercontent.com/sclorg/django-ex/${branch}/openshift/templates/${template}" \
                                      "${IMAGE_NAME}" \
                                      'python' \
                                      'Welcome to your Django application on OpenShift' \
                                      8080 http 200 "-p SOURCE_REPOSITORY_REF=$branch -p PYTHON_VERSION=${VERSION}${tag} -p POSTGRESQL_VERSION=${postgresql_version} -p NAME=python-testing" \
                                      "$postgresql_image"
+  done
 }
 
 function test_python_s2i_app_ex_standalone() {
@@ -90,8 +95,8 @@ function test_python_s2i_app_ex() {
 function test_python_s2i_templates() {
   if [ -z "${EPHEMERAL_TEMPLATES:-}" ]; then
       EPHEMERAL_TEMPLATES="
-https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django-postgresql.json \
-https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/django-postgresql.json"
+django-postgresql.json \
+django-postgresql-persistent.json"
   fi
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
@@ -110,7 +115,7 @@ https://raw.githubusercontent.com/openshift/origin/master/examples/quickstarts/d
         branch="2.2.x"
       fi
       ct_os_test_template_app "$IMAGE_NAME" \
-                              "$template" \
+                              "https://raw.githubusercontent.com/sclorg/django-ex/${branch}/openshift/templates/${template}" \
                               python \
                               'Welcome to your Django application on OpenShift' \
                               8080 http 200 "-p SOURCE_REPOSITORY_REF=$branch -p PYTHON_VERSION=${VERSION} -p POSTGRESQL_VERSION=${postgresql_version} -p NAME=python-testing" \


### PR DESCRIPTION
Migration from DeploymentConfig to Deployment

For more information see
https://docs.openshift.com/container-platform/4.12/applications/deployments/what-deployments-are.html

Since OpenShift 4.14 DeploymentConfigs are deprecated. https://access.redhat.com/articles/7041372

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
