### PR TITLE
build Fedora and CentOS Stream images also for arm64

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -97,3 +97,4 @@ jobs:
           dockerfile: ${{ matrix.dockerfile }}
           tag: ${{ matrix.tag }}
           image_name: ${{ matrix.image_name }}
+          archs: amd64, arm64


### PR DESCRIPTION
Depends on: https://github.com/sclorg/s2i-base-container/pull/292
Resolves: https://github.com/sclorg/s2i-python-container/issues/659
