### PR TITLE
Add show imagestreams

### DIFF
--- a/test/show_all_imagestreams.py
+++ b/test/show_all_imagestreams.py
@@ -1,0 +1,1 @@
+../common/show_all_imagestreams.py


### PR DESCRIPTION
This pull request only adds show_all_imagestreams.py so it is working.

The file `show_all_imagestreams.py` shows all available imagestreams for this container, that are specified
in the directory `imagestreams`.

The example output will be seen in the next comment.
