### PR TITLE
Fix PyTest test suite

### DIFF
--- a/imagestreams/imagestreams.yaml
+++ b/imagestreams/imagestreams.yaml
@@ -12,9 +12,6 @@
   - filename: python-centos.json
     latest: "3.9-ubi9"
     distros:
-      - name: UBI 7
-        app_versions: ["3.8"]
-
       - name: UBI 8
         app_versions: ["3.6", "3.8", "3.9", "3.12"]
 
@@ -24,18 +21,11 @@
   - filename: python-rhel.json
     latest: "3.11-ubi8"
     distros:
-      - name: UBI 7
-        app_versions: ["3.8"]
-
       - name: UBI 8
         app_versions: ["3.6", "3.8", "3.9", "3.11", "3.12"]
 
       - name: UBI 9
         app_versions: ["3.9", "3.11", "3.12"]
-    custom_tags:
-      - name: "3.8"
-        distro: RHEL 7
-        app_version: "3.8"
 
   - filename: python-rhel-aarch64.json
     latest: "3.9-ubi8"

--- a/imagestreams/python-centos.json
+++ b/imagestreams/python-centos.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "3.8-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Python 3.8 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python",
-          "version": "3.8",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.access.redhat.com/ubi7/python-38:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "3.6-ubi8",
         "annotations": {
           "openshift.io/display-name": "Python 3.6 (UBI 8)",

--- a/imagestreams/python-rhel.json
+++ b/imagestreams/python-rhel.json
@@ -10,25 +10,6 @@
   "spec": {
     "tags": [
       {
-        "name": "3.8-ubi7",
-        "annotations": {
-          "openshift.io/display-name": "Python 3.8 (UBI 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 3.8 applications on UBI 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python",
-          "version": "3.8",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/ubi7/python-38:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
         "name": "3.6-ubi8",
         "annotations": {
           "openshift.io/display-name": "Python 3.6 (UBI 8)",
@@ -175,25 +156,6 @@
         "from": {
           "kind": "DockerImage",
           "name": "registry.redhat.io/ubi9/python-312:latest"
-        },
-        "referencePolicy": {
-          "type": "Local"
-        }
-      },
-      {
-        "name": "3.8",
-        "annotations": {
-          "openshift.io/display-name": "Python 3.8 (RHEL 7)",
-          "openshift.io/provider-display-name": "Red Hat, Inc.",
-          "description": "Build and run Python 3.8 applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.",
-          "iconClass": "icon-python",
-          "tags": "builder,python",
-          "version": "3.8",
-          "sampleRepo": "https://github.com/sclorg/django-ex.git"
-        },
-        "from": {
-          "kind": "DockerImage",
-          "name": "registry.redhat.io/rhscl/python-38-rhel7:latest"
         },
         "referencePolicy": {
           "type": "Local"

--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -21,7 +21,7 @@ DEPLOYED_PSQL_IMAGE = "quay.io/centos7/postgresql-10-centos7:centos7"
 IMAGE_TAG = "postgresql:10"
 PSQL_VERSION = "10"
 
-if VERSION == "3.11":
+if VERSION == "3.11" or VERSION == "3.12":
     DEPLOYED_PSQL_IMAGE = "quay.io/sclorg/postgresql-12-c8s"
     IMAGE_TAG = "postgresql:12"
     PSQL_VERSION = "12"


### PR DESCRIPTION
This pull request adds condition also for Python-3.12.

The pull request also removes 'django-postgresql' storage as it does not make sense.
Only 'persistent' is used in real production. It also adds 'django' application alone.

Allow only persistent Django storage and Django alone for testing

