### PR TITLE
Allow testing s2i-python-container in C10S

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "3.8", "3.9", "3.9-minimal", "3.11", "3.11-minimal", "3.12" ]
-        os_test: [ "fedora", "rhel8", "rhel9", "c9s" ]
+        os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
         test_case: [ "container" ]
     if: |
       github.event.issue.pull_request


### PR DESCRIPTION
This pull request only allows testing s2i-python-container in C10S.

No Python functionality is broken.
Only GitHub Action is updated.
