### PR TITLE
Enable testing F41-Py3.13 on CI

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -118,6 +118,14 @@ jobs:
             tag: "c10s"
             image_name: "python-312-c10s"
 
+          - dockerfile: "3.13/Dockerfile.fedora"
+            docker_context: "3.13"
+            registry_namespace: "fedora"
+            quayio_username: "QUAY_IMAGE_FEDORA_BUILDER_USERNAME"
+            quayio_token: "QUAY_IMAGE_FEDORA_BUILDER_TOKEN"
+            tag: "313"
+            image_name: "python-313"
+
     steps:
       - name: Build and push to quay.io registry
         uses: sclorg/build-and-push-action@v4

--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "3.8", "3.9", "3.9-minimal", "3.11", "3.11-minimal", "3.12", "3.12-minimal" ]
+        version: [ "3.9", "3.9-minimal", "3.11", "3.11-minimal", "3.12", "3.12-minimal", "3.13" ]
         os_test: [ "fedora", "rhel8", "rhel9", "c9s", "c10s" ]
         test_case: [ "container" ]
     if: |

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Download
 --------
 To download one of the base Python images, follow the instructions you find in registries mentioned above.
 
-For example, Centos image can be downloaded via:
+For example, CentOS Stream image can be downloaded via:
 
 ```
-$ podman pull quay.io/c9s/python-38-c9s
+$ podman pull quay.io/c9s/python-39-c9s
 ```
 
 Build
@@ -89,7 +89,7 @@ To build a Python image from scratch run:
 ```
 $ git clone https://github.com/sclorg/s2i-python-container.git
 $ cd s2i-python-container
-$ make build TARGET=c9s VERSIONS=3.8
+$ make build TARGET=c9s VERSIONS=3.9
 ```
 
 Where `TARGET` might be one of the supported platforms mentioned above.
@@ -108,7 +108,7 @@ which launches tests to check functionality of simple Python applications built 
 
 ```
 $ cd s2i-python-container
-$ make test TARGET=c9s VERSIONS=3.8
+$ make test TARGET=c9s VERSIONS=3.9
 ```
 
 Where `TARGET` might be one of the supported platforms mentioned above.
@@ -131,7 +131,7 @@ Repository organization
 
     * **Dockerfile.rhel8** & **Dockerfile.rhel9**
 
-        RHEL 7/8 based Dockerfile. In order to perform build or test actions on this
+        RHEL 8/9 based Dockerfile. In order to perform build or test actions on this
         Dockerfile you need to run the action on a properly subscribed RHEL machine.
 
     * **`s2i/bin/`**


### PR DESCRIPTION
I need to have it in place before hacking the image.