### PR TITLE
Fix image url

### DIFF
--- a/3.13/README.md
+++ b/3.13/README.md
@@ -74,7 +74,7 @@ To use the Python image in a Dockerfile, follow these steps:
 #### 1. Pull a base builder image to build on
 
 ```
-podman pull https://quay.io/fedora/python-313
+podman pull quay.io/fedora/python-313
 ```
 
 #### 2. Pull and application code
@@ -105,7 +105,7 @@ prepared for a future flawless switch to a newer or different platform.
 To use the Source-to-Image scripts and build an image using a Dockerfile, create a Dockerfile with this content:
 
 ```
-FROM https://quay.io/fedora/python-313
+FROM quay.io/fedora/python-313
 
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
@@ -125,7 +125,7 @@ If you decide not to use the Source-to-Image scripts, you will need to manually 
 Example Dockerfile for a simple Django application:
 
 ```
-FROM https://quay.io/fedora/python-313
+FROM quay.io/fedora/python-313
 
 # Add application sources with correct permissions for OpenShift
 USER 0

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -121,7 +121,7 @@ specs:
       # Python 3.13 doesn't come as a module
       module_stream: ""
       pkg_prefix: "python3.13"
-      main_image: "https://quay.io/fedora/python-313"
+      main_image: "quay.io/fedora/python-313"
 
     "3.12-minimal":
       version: "3.12"


### PR DESCRIPTION
Fixes: #722 

















































































































<!-- testing-farm = {"lock":"false","comment-id":"2591979172","data":[{"id":"4f36a383-3550-479f-b9b1-f059cddab183","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1004.206793,"created":"2025-01-15T08:35:15.094215","updated":"2025-01-15T08:35:15.094222","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4f36a383-3550-479f-b9b1-f059cddab183\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4f36a383-3550-479f-b9b1-f059cddab183/pipeline.log\">pipeline</a>"]},{"id":"39188ed2-672c-4be1-ac74-03cddb875459","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1116.005921,"created":"2025-01-15T08:35:14.569327","updated":"2025-01-15T08:35:14.569336","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/39188ed2-672c-4be1-ac74-03cddb875459\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/39188ed2-672c-4be1-ac74-03cddb875459/pipeline.log\">pipeline</a>"]},{"id":"0aca8a4c-b03a-4f90-91cb-7351f2a52b0c","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1127.251877,"created":"2025-01-15T08:35:14.548331","updated":"2025-01-15T08:35:14.548339","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0aca8a4c-b03a-4f90-91cb-7351f2a52b0c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0aca8a4c-b03a-4f90-91cb-7351f2a52b0c/pipeline.log\">pipeline</a>"]},{"id":"6b8423a5-ec0c-4aae-89ea-74d90c4292ea","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1125.656437,"created":"2025-01-15T08:35:56.439626","updated":"2025-01-15T08:35:56.439634","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6b8423a5-ec0c-4aae-89ea-74d90c4292ea\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6b8423a5-ec0c-4aae-89ea-74d90c4292ea/pipeline.log\">pipeline</a>"]},{"id":"efece02d-7d50-477a-bf7f-178594a4647a","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1173.639966,"created":"2025-01-15T08:35:31.533386","updated":"2025-01-15T08:35:31.533394","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/efece02d-7d50-477a-bf7f-178594a4647a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/efece02d-7d50-477a-bf7f-178594a4647a/pipeline.log\">pipeline</a>"]},{"id":"dd8614a1-4e83-4ba7-8416-591a4f90e260","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1181.146024,"created":"2025-01-15T08:35:16.932181","updated":"2025-01-15T08:35:16.932189","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dd8614a1-4e83-4ba7-8416-591a4f90e260\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dd8614a1-4e83-4ba7-8416-591a4f90e260/pipeline.log\">pipeline</a>"]},{"id":"ed72348c-1a0a-4969-82f5-897b9ed5ef0a","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1217.259871,"created":"2025-01-15T08:35:13.832719","updated":"2025-01-15T08:35:13.832728","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ed72348c-1a0a-4969-82f5-897b9ed5ef0a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed72348c-1a0a-4969-82f5-897b9ed5ef0a/pipeline.log\">pipeline</a>"]},{"id":"efc6278d-ec0e-4044-9015-c264c7bb088e","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1242.971178,"created":"2025-01-15T08:35:14.743838","updated":"2025-01-15T08:35:14.743847","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/efc6278d-ec0e-4044-9015-c264c7bb088e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/efc6278d-ec0e-4044-9015-c264c7bb088e/pipeline.log\">pipeline</a>"]},{"id":"24054dad-e693-482c-95a1-86c0ffc75e06","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1329.418134,"created":"2025-01-15T08:35:14.528238","updated":"2025-01-15T08:35:14.528244","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/24054dad-e693-482c-95a1-86c0ffc75e06\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/24054dad-e693-482c-95a1-86c0ffc75e06/pipeline.log\">pipeline</a>"]},{"id":"dc196c87-0ee3-4afd-a113-487afc73fa8e","name":"Fedora - 3.13","status":"complete","outcome":"error","runTime":1417.210283,"created":"2025-01-15T08:35:23.729008","updated":"2025-01-15T08:35:23.729018","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dc196c87-0ee3-4afd-a113-487afc73fa8e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dc196c87-0ee3-4afd-a113-487afc73fa8e/pipeline.log\">pipeline</a>"]},{"id":"891e4697-a4bf-41be-bfdc-914e84922ff8","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1456.361662,"created":"2025-01-15T08:35:14.664340","updated":"2025-01-15T08:35:14.664347","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/891e4697-a4bf-41be-bfdc-914e84922ff8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/891e4697-a4bf-41be-bfdc-914e84922ff8/pipeline.log\">pipeline</a>"]},{"id":"aa4f15bc-c72d-4d70-891e-e2ff37ba442a","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1519.413899,"created":"2025-01-15T08:35:14.454076","updated":"2025-01-15T08:35:14.454084","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa4f15bc-c72d-4d70-891e-e2ff37ba442a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/aa4f15bc-c72d-4d70-891e-e2ff37ba442a/pipeline.log\">pipeline</a>"]},{"id":"45e5ddfe-0fa1-404a-8746-ab12c6a1f364","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1535.524328,"created":"2025-01-15T08:35:17.718540","updated":"2025-01-15T08:35:17.718549","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/45e5ddfe-0fa1-404a-8746-ab12c6a1f364\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/45e5ddfe-0fa1-404a-8746-ab12c6a1f364/pipeline.log\">pipeline</a>"]},{"id":"a4a65425-5c2f-4a55-84c2-4b9c13c99578","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1531.607359,"created":"2025-01-15T08:35:17.413738","updated":"2025-01-15T08:35:17.413745","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4a65425-5c2f-4a55-84c2-4b9c13c99578\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a4a65425-5c2f-4a55-84c2-4b9c13c99578/pipeline.log\">pipeline</a>"]},{"id":"b6a2dab1-b33b-4f07-b14b-c3f474c6a211","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1537.389021,"created":"2025-01-15T08:35:14.368855","updated":"2025-01-15T08:35:14.368861","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6a2dab1-b33b-4f07-b14b-c3f474c6a211\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6a2dab1-b33b-4f07-b14b-c3f474c6a211/pipeline.log\">pipeline</a>"]},{"id":"bcfdc079-0225-4eef-b29e-fa418015518c","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1578.515759,"created":"2025-01-15T08:35:32.617480","updated":"2025-01-15T08:35:32.617487","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bcfdc079-0225-4eef-b29e-fa418015518c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bcfdc079-0225-4eef-b29e-fa418015518c/pipeline.log\">pipeline</a>"]},{"id":"ceda909d-6339-4b3d-bd99-fd4b3c6cb747","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1661.113866,"created":"2025-01-15T08:35:37.649451","updated":"2025-01-15T08:35:37.649457","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ceda909d-6339-4b3d-bd99-fd4b3c6cb747\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ceda909d-6339-4b3d-bd99-fd4b3c6cb747/pipeline.log\">pipeline</a>"]},{"id":"e6e4703e-edb9-4854-924c-49847828dfbf","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1727.578556,"created":"2025-01-15T08:35:14.946467","updated":"2025-01-15T08:35:14.946476","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e6e4703e-edb9-4854-924c-49847828dfbf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e6e4703e-edb9-4854-924c-49847828dfbf/pipeline.log\">pipeline</a>"]},{"id":"fc1979c0-3254-4832-bc8b-a64dd6c46fdb","name":"RHEL8 - 3.12","runTime":1851.341344,"created":"2025-01-15T08:35:14.074336","updated":"2025-01-15T08:35:14.074344","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc1979c0-3254-4832-bc8b-a64dd6c46fdb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fc1979c0-3254-4832-bc8b-a64dd6c46fdb/pipeline.log\">pipeline</a>"]}]} -->