### PR TITLE
Switch to Django 4.2.x from django-ex project for newer Pythons

### DIFF
--- a/3.11-minimal/test/run
+++ b/3.11-minimal/test/run
@@ -192,7 +192,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.11/test/run
+++ b/3.11/test/run
@@ -196,7 +196,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.12-minimal/test/run
+++ b/3.12-minimal/test/run
@@ -192,7 +192,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.12/test/run
+++ b/3.12/test/run
@@ -196,7 +196,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.13/test/run
+++ b/3.13/test/run
@@ -196,7 +196,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.9-minimal/test/run
+++ b/3.9-minimal/test/run
@@ -192,7 +192,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/3.9/test/run
+++ b/3.9/test/run
@@ -196,7 +196,8 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
-  django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?

--- a/test/run
+++ b/test/run
@@ -204,7 +204,12 @@ test_application() {
 
 test_from_dockerfile(){
   info "Test from Dockerfile"
+  {% if spec.version == "3.6" %}
   django_example_repo_url="https://github.com/sclorg/django-ex.git@2.2.x"
+  {% else %}
+  # Django 4.2 supports Python 3.9+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git@4.2.x"
+  {% endif %}
 
   ct_test_app_dockerfile $test_dir/from-dockerfile/Dockerfile.tpl $django_example_repo_url 'Welcome to your Django application on OpenShift' app-src
   ct_check_testcase_result $?


### PR DESCRIPTION
Django 4.2 LTS is still supported.