### PR TITLE
Support python 312 minimal rhel9

### DIFF
--- a/3.11-minimal/Dockerfile.c9s
+++ b/3.11-minimal/Dockerfile.c9s
@@ -74,7 +74,7 @@ COPY 3.11-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.11/root/opt/wheels /opt/wheels
+COPY 3.11-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.11-minimal/Dockerfile.rhel8
+++ b/3.11-minimal/Dockerfile.rhel8
@@ -74,7 +74,7 @@ COPY 3.11-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.11/root/opt/wheels /opt/wheels
+COPY 3.11-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.12-minimal/Dockerfile.c10s
+++ b/3.12-minimal/Dockerfile.c10s
@@ -74,7 +74,7 @@ COPY 3.12-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.12/root/opt/wheels /opt/wheels
+COPY 3.12-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.12-minimal/Dockerfile.fedora
+++ b/3.12-minimal/Dockerfile.fedora
@@ -74,7 +74,7 @@ COPY 3.12-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.12/root/opt/wheels /opt/wheels
+COPY 3.12-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.12-minimal/Dockerfile.rhel8
+++ b/3.12-minimal/Dockerfile.rhel8
@@ -74,7 +74,7 @@ COPY 3.12-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.12/root/opt/wheels /opt/wheels
+COPY 3.12-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.12-minimal/Dockerfile.rhel9
+++ b/3.12-minimal/Dockerfile.rhel9
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9-minimal
+FROM ubi9/ubi-minimal:latest
 
 
 EXPOSE 8080
@@ -47,7 +47,7 @@ LABEL summary="$SUMMARY" \
       io.openshift.expose-services="8080:http" \
       io.openshift.tags="builder,python,python312,python-312,rh-python312" \
       com.redhat.component="python-312-container" \
-      name="sclorg/python-312-minimal-c9s" \
+      name="ubi9/python-312-minimal" \
       version="1" \
       usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.12-minimal/test/setup-test-app/ ubi9/python-312-minimal python-sample-app" \
       com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \

--- a/3.9-minimal/Dockerfile.c9s
+++ b/3.9-minimal/Dockerfile.c9s
@@ -74,7 +74,7 @@ COPY 3.9-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.9/root/opt/wheels /opt/wheels
+COPY 3.9-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/3.9-minimal/Dockerfile.rhel8
+++ b/3.9-minimal/Dockerfile.rhel8
@@ -74,7 +74,7 @@ COPY 3.9-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY 3.9/root/opt/wheels /opt/wheels
+COPY 3.9-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -33,6 +33,7 @@ specs:
       distros:
         - rhel-9-x86_64
       el_version: "9"
+      minimal_image: "ubi9/ubi-minimal:latest"
       s2i_base: ubi9/s2i-base
       img_tag: "1"
       org: "ubi9"
@@ -232,6 +233,7 @@ matrix:
         - centos-stream-10-x86_64
         - centos-stream-9-x86_64
         - rhel-8-x86_64
+        - rhel-9-x86_64
       version: "3.12-minimal"
     - distros:
         - fedora-41-x86_64

--- a/src/Dockerfile-minimal.template
+++ b/src/Dockerfile-minimal.template
@@ -76,7 +76,7 @@ COPY {{ spec.version }}-minimal/root/ /
 # The problem here is that the wheels directory is copied as a symlink.
 # Only if you specify symlink directly as a source, COPY copies all the
 # files from the symlink destination.
-COPY {{ spec.version }}/root/opt/wheels /opt/wheels
+COPY {{ spec.version }}-minimal/root/opt/wheels /opt/wheels
 
 # This command sets (and also creates if necessary)
 # the home directory - it has to be done here so the latter


### PR DESCRIPTION
This pull request adds support for Python-312-minimal container on RHEL9 host.

The first commit modified dist-gen sources.
The second commit adds generated source by dist-gen.




























































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2609437238","data":[{"id":"adeb55cb-dde9-4ac2-a0f2-282703d52dfd","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":942.785605,"created":"2025-01-23T14:55:37.716178","updated":"2025-01-23T14:55:37.716189","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/adeb55cb-dde9-4ac2-a0f2-282703d52dfd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/adeb55cb-dde9-4ac2-a0f2-282703d52dfd/pipeline.log\">pipeline</a>"]},{"id":"9cafcff3-be21-4053-b7bc-9fa3f9c23a91","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1062.255086,"created":"2025-01-23T14:55:39.984767","updated":"2025-01-23T14:55:39.984776","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9cafcff3-be21-4053-b7bc-9fa3f9c23a91\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9cafcff3-be21-4053-b7bc-9fa3f9c23a91/pipeline.log\">pipeline</a>"]},{"id":"379e76ba-d849-4e89-b448-0e7e8925e314","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1112.044899,"created":"2025-01-23T14:55:35.208984","updated":"2025-01-23T14:55:35.208995","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/379e76ba-d849-4e89-b448-0e7e8925e314\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/379e76ba-d849-4e89-b448-0e7e8925e314/pipeline.log\">pipeline</a>"]},{"id":"8b5e8271-ce4f-4f6e-ac9e-70daa7bd0566","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1064.257996,"created":"2025-01-23T14:55:25.121718","updated":"2025-01-23T14:55:25.121731","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8b5e8271-ce4f-4f6e-ac9e-70daa7bd0566\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8b5e8271-ce4f-4f6e-ac9e-70daa7bd0566/pipeline.log\">pipeline</a>"]},{"id":"c15f0d79-098c-4767-8f01-157cdd969db0","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1166.384461,"created":"2025-01-23T14:55:38.038030","updated":"2025-01-23T14:55:38.038042","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c15f0d79-098c-4767-8f01-157cdd969db0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c15f0d79-098c-4767-8f01-157cdd969db0/pipeline.log\">pipeline</a>"]},{"id":"33cdffe8-97be-4960-b3f9-d1e3e30a098c","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1162.529009,"created":"2025-01-23T14:55:53.553021","updated":"2025-01-23T14:55:53.553030","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/33cdffe8-97be-4960-b3f9-d1e3e30a098c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/33cdffe8-97be-4960-b3f9-d1e3e30a098c/pipeline.log\">pipeline</a>"]},{"id":"08fed386-7a0f-41bf-816a-001b269e685e","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1143.932567,"created":"2025-01-23T14:55:38.558920","updated":"2025-01-23T14:55:38.558927","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/08fed386-7a0f-41bf-816a-001b269e685e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/08fed386-7a0f-41bf-816a-001b269e685e/pipeline.log\">pipeline</a>"]},{"id":"e5c04c12-b7c8-41b0-9062-1297213d39eb","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1186.159262,"created":"2025-01-23T14:55:24.300830","updated":"2025-01-23T14:55:24.300837","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e5c04c12-b7c8-41b0-9062-1297213d39eb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e5c04c12-b7c8-41b0-9062-1297213d39eb/pipeline.log\">pipeline</a>"]},{"id":"994e6ce2-bdfb-47eb-828f-6f4afcaa9179","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1284.263723,"created":"2025-01-23T14:55:45.526696","updated":"2025-01-23T14:55:45.526705","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/994e6ce2-bdfb-47eb-828f-6f4afcaa9179\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/994e6ce2-bdfb-47eb-828f-6f4afcaa9179/pipeline.log\">pipeline</a>"]},{"id":"b8214fe9-0a80-40cc-a166-06b0c2f6da17","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1273.284088,"created":"2025-01-23T14:55:55.828437","updated":"2025-01-23T14:55:55.828444","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b8214fe9-0a80-40cc-a166-06b0c2f6da17\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b8214fe9-0a80-40cc-a166-06b0c2f6da17/pipeline.log\">pipeline</a>"]},{"id":"1f5a1105-5a73-4b05-be84-2a82f03e59e7","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1384.853723,"created":"2025-01-23T10:57:31.198927","updated":"2025-01-23T10:57:31.198936","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f5a1105-5a73-4b05-be84-2a82f03e59e7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f5a1105-5a73-4b05-be84-2a82f03e59e7/pipeline.log\">pipeline</a>"]},{"id":"9486c73b-17ae-4113-ade5-635156135ec0","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1052.54692,"created":"2025-01-23T14:55:49.425062","updated":"2025-01-23T14:55:49.425069","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9486c73b-17ae-4113-ade5-635156135ec0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9486c73b-17ae-4113-ade5-635156135ec0/pipeline.log\">pipeline</a>"]},{"id":"2995f070-b7c6-4460-b930-94bafb51a6b1","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1594.961281,"created":"2025-01-23T14:55:41.968994","updated":"2025-01-23T14:55:41.969003","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2995f070-b7c6-4460-b930-94bafb51a6b1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2995f070-b7c6-4460-b930-94bafb51a6b1/pipeline.log\">pipeline</a>"]},{"id":"2b1604d7-3148-4fc3-afb7-7bb24ea857ec","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1592.020024,"created":"2025-01-23T14:55:42.613331","updated":"2025-01-23T14:55:42.613340","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b1604d7-3148-4fc3-afb7-7bb24ea857ec\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2b1604d7-3148-4fc3-afb7-7bb24ea857ec/pipeline.log\">pipeline</a>"]},{"id":"3716ae66-c1e0-4ab5-b243-0c8db45df282","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1560.395846,"created":"2025-01-23T14:55:49.146945","updated":"2025-01-23T14:55:49.146954","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3716ae66-c1e0-4ab5-b243-0c8db45df282\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3716ae66-c1e0-4ab5-b243-0c8db45df282/pipeline.log\">pipeline</a>"]},{"id":"dbb7ffa4-35f7-4c0f-ad97-668fdf4eda85","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1674.463194,"created":"2025-01-23T15:12:11.128450","updated":"2025-01-23T15:12:11.128458","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbb7ffa4-35f7-4c0f-ad97-668fdf4eda85\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dbb7ffa4-35f7-4c0f-ad97-668fdf4eda85/pipeline.log\">pipeline</a>"]},{"id":"bcf6827b-4dbe-40e1-9226-6ab43bc0d777","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1588.473316,"created":"2025-01-23T14:55:50.372742","updated":"2025-01-23T14:55:50.372750","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bcf6827b-4dbe-40e1-9226-6ab43bc0d777\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bcf6827b-4dbe-40e1-9226-6ab43bc0d777/pipeline.log\">pipeline</a>"]},{"id":"05a0c2bc-520e-4c74-bbca-2b3844f46dce","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1805.020389,"created":"2025-01-23T14:55:48.341491","updated":"2025-01-23T14:55:48.341499","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/05a0c2bc-520e-4c74-bbca-2b3844f46dce\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/05a0c2bc-520e-4c74-bbca-2b3844f46dce/pipeline.log\">pipeline</a>"]},{"id":"8f723c85-9695-499b-8be9-2401220d7f1d","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1982.407548,"created":"2025-01-23T14:55:42.428841","updated":"2025-01-23T14:55:42.428849","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f723c85-9695-499b-8be9-2401220d7f1d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8f723c85-9695-499b-8be9-2401220d7f1d/pipeline.log\">pipeline</a>"]},{"id":"dcd56397-111c-4db8-b6ca-095b69100483","name":"RHEL8 - 3.12","runTime":1995.471339,"created":"2025-01-23T15:07:58.343978","updated":"2025-01-23T15:07:58.343990","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/dcd56397-111c-4db8-b6ca-095b69100483\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/dcd56397-111c-4db8-b6ca-095b69100483/pipeline.log\">pipeline</a>"]},{"id":"b52ce519-097d-4ab4-942a-a56d73225aeb","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1555.581238,"created":"2025-01-23T14:55:51.088225","updated":"2025-01-23T14:55:51.088235","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b52ce519-097d-4ab4-942a-a56d73225aeb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b52ce519-097d-4ab4-942a-a56d73225aeb/pipeline.log\">pipeline</a>"]}]} -->