### PR TITLE
Support building and testing s2i-python-container on RHEL10 host

### DIFF
--- a/3.12-minimal/Dockerfile.rhel10
+++ b/3.12-minimal/Dockerfile.rhel10
@@ -1,0 +1,108 @@
+FROM ubi10-minimal:latest
+
+
+EXPOSE 8080
+
+ENV PYTHON_VERSION=3.12 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    CNB_STACK_ID=com.redhat.stacks.ubi10-python-312 \
+    CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0 \
+    PIP_NO_CACHE_DIR=off \
+    # The following variables are usually available from parent s2i images \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    HOME=/opt/app-root/src \
+    PLATFORM="el10"
+
+# /opt/app-root/bin - the main venv
+# /opt/app-root/src/bin - app-specific binaries
+# /opt/app-root/src/.local/bin - tools like pipenv
+ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
+
+# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
+# images, however, don't as most images don't need SCLs any more. But we want
+# to run it even on RHEL8, because we set the virtualenv environment as part of
+# that script
+ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
+    ENV=${APP_ROOT}/etc/scl_enable \
+    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+
+ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
+    DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \
+building and running various Python $PYTHON_VERSION applications and frameworks. \
+Python is an easy to learn, powerful programming language. It has efficient high-level \
+data structures and a simple but effective approach to object-oriented programming. \
+Python's elegant syntax and dynamic typing, together with its interpreted nature, \
+make it an ideal language for scripting and rapid application development in many areas \
+on most platforms."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Python 3.12" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,python,python312,python-312,rh-python312" \
+      com.redhat.component="python-312-container" \
+      name="ubi10/python-312-minimal" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.12-minimal/test/setup-test-app/ ubi10/python-312-minimal python-sample-app" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      io.buildpacks.stack.id="com.redhat.stacks.ubi10-python-312-minimal" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Very minimal set of packages
+# Python is obvious in the Python container :)
+# glibc-langpack-en is needed to set locale to en_US and disable warning about it
+# findutils - find command is needed for fix-permissions script
+# nss_wrapper - used in generate_container_user script
+RUN INSTALL_PKGS="python3.12 glibc-langpack-en findutils nss_wrapper-libs" && \
+    microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    microdnf -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY 3.12-minimal/s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY 3.12-minimal/root/ /
+
+# Python 3.7+ only
+# Yes, the directory below is already copied by the previous command.
+# The problem here is that the wheels directory is copied as a symlink.
+# Only if you specify symlink directly as a source, COPY copies all the
+# files from the symlink destination.
+COPY 3.12-minimal/root/opt/wheels /opt/wheels
+
+# This command sets (and also creates if necessary)
+# the home directory - it has to be done here so the latter
+# fix-permissions fixes this directory as well.
+WORKDIR ${HOME}
+
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
+RUN \
+    python3.12 -m venv ${APP_ROOT} && \
+    # We have to upgrade pip to a newer version because \
+    # pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 (and later) wheels \
+    #   support platforms like ppc64le, aarch64 or armv7 \
+    # We are newly using wheel from one of the latest stable Fedora releases (from RPM python-pip-wheel) \
+    # because it's tested better then whatever version from PyPI and contains useful patches. \
+    # We have to do it here so the permissions are correctly fixed and pip is able \
+    # to reinstall itself in the next build phases in the assemble script if user wants the latest version \
+    ${APP_ROOT}/bin/pip install /opt/wheels/pip-* && \
+    rm -r /opt/wheels && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image.
+CMD $STI_SCRIPTS_PATH/usage

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Python versions currently provided are:
 RHEL versions currently supported are:
 * RHEL 8 ([catalog.redhat.com](https://catalog.redhat.com/software/containers/search))
 * RHEL 9 ([catalog.redhat.com](https://catalog.redhat.com/software/containers/search))
+* RHEL 10 ([catalog.redhat.com](https://catalog.redhat.com/software/containers/search))
 
 CentOS Stream versions currently supported are:
 * CentOS Stream 9 ([quay.io/sclorg](https://quay.io/organization/sclorg))

--- a/manifest-minimal.yml
+++ b/manifest-minimal.yml
@@ -51,6 +51,9 @@ DISTGEN_MULTI_RULES:
     dest: Dockerfile.rhel9
 
   - src: src/Dockerfile-minimal.template
+    dest: Dockerfile.rhel10
+
+  - src: src/Dockerfile-minimal.template
     dest: Dockerfile.fedora
 
   - src: src/Dockerfile-minimal.template

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -50,6 +50,26 @@ specs:
         "3.11": ['python3.11', 'python3.11-devel', 'python3.11-pip']
         "3.12": ['python3.12', 'python3.12-devel', 'python3.12-pip']
 
+    rhel10:
+      distros:
+        - rhel-10-x86_64
+      el_version: "10"
+      minimal_image: "ubi10-minimal:latest"
+      s2i_base: ubi10/s2i-base
+      img_tag: "1"
+      org: "ubi10"
+      prod: "rhel10"
+      logos: "redhat-logos-httpd"
+      python_pkgs: []
+      base_pkgs: ['nss_wrapper-libs', 'httpd', 'httpd-devel', 'mod_ssl',
+                  'mod_auth_gssapi', 'mod_ldap', 'mod_session',
+                  'atlas-devel', 'gcc-gfortran', 'libffi-devel', 'libtool-ltdl', 'enchant',
+                  'krb5-devel']
+      ubi_versions: ['3.12']
+      extra_pkgs:
+        "3.12": ['python3.12', 'python3.12-devel', 'python3.12-pip']
+
+
     c9s:
       distros:
         - centos-stream-9-x86_64
@@ -234,6 +254,7 @@ matrix:
         - centos-stream-9-x86_64
         - rhel-8-x86_64
         - rhel-9-x86_64
+        - rhel-10-x86_64
       version: "3.12-minimal"
     - distros:
         - fedora-41-x86_64


### PR DESCRIPTION
This pull request adds support for building and testing s2i-python-container on RHEL10 host.

The pull request is separated into three commit:
- the first adds support for building container in RHEL10 to spec files
- The second commit adds distgen generated files
- the third commit updates README.md file




































































































































































































































































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2615425193","data":[{"id":"372cf74a-01f5-440f-84ba-d7b018276f22","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1645.582447,"created":"2025-01-27T13:16:30.512847","updated":"2025-01-27T13:16:30.512853","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/372cf74a-01f5-440f-84ba-d7b018276f22\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/372cf74a-01f5-440f-84ba-d7b018276f22/pipeline.log\">pipeline</a>"]},{"id":"bdf0a54f-3179-4c4c-b393-b2af3e8cb482","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1631.678798,"created":"2025-01-27T13:16:27.848724","updated":"2025-01-27T13:16:27.848731","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdf0a54f-3179-4c4c-b393-b2af3e8cb482\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bdf0a54f-3179-4c4c-b393-b2af3e8cb482/pipeline.log\">pipeline</a>"]},{"id":"0d8d5831-cfef-4c08-a97f-6043b2b53507","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1879.489347,"created":"2025-01-27T13:16:28.174316","updated":"2025-01-27T13:16:28.174323","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d8d5831-cfef-4c08-a97f-6043b2b53507\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d8d5831-cfef-4c08-a97f-6043b2b53507/pipeline.log\">pipeline</a>"]},{"id":"927f4efd-93be-4408-8d26-aed8b6be87f9","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1575.270448,"created":"2025-01-27T13:16:29.526521","updated":"2025-01-27T13:16:29.526528","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/927f4efd-93be-4408-8d26-aed8b6be87f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/927f4efd-93be-4408-8d26-aed8b6be87f9/pipeline.log\">pipeline</a>"]},{"id":"6192bf6d-2504-4580-b0c0-8e4a4f2af17a","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1548.644175,"created":"2025-01-27T13:16:38.434827","updated":"2025-01-27T13:16:38.434833","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6192bf6d-2504-4580-b0c0-8e4a4f2af17a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6192bf6d-2504-4580-b0c0-8e4a4f2af17a/pipeline.log\">pipeline</a>"]},{"id":"5f90cfca-ae94-4b5d-88e4-0101e24006c5","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1380.983842,"created":"2025-01-27T13:16:38.667156","updated":"2025-01-27T13:16:38.667165","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f90cfca-ae94-4b5d-88e4-0101e24006c5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f90cfca-ae94-4b5d-88e4-0101e24006c5/pipeline.log\">pipeline</a>"]},{"id":"d8b34ff8-bcc4-47d6-bbef-9b75b8d722e5","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1498.045972,"created":"2025-01-27T13:16:38.192001","updated":"2025-01-27T13:16:38.192008","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8b34ff8-bcc4-47d6-bbef-9b75b8d722e5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8b34ff8-bcc4-47d6-bbef-9b75b8d722e5/pipeline.log\">pipeline</a>"]},{"id":"a6a9860d-4569-46c1-b6a5-cc2748238750","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1549.409821,"created":"2025-01-27T13:33:27.215007","updated":"2025-01-27T13:33:27.215016","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6a9860d-4569-46c1-b6a5-cc2748238750\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a6a9860d-4569-46c1-b6a5-cc2748238750/pipeline.log\">pipeline</a>"]},{"id":"84dba3f1-9e31-4bf3-ba3c-348a64c622dd","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1796.164784,"created":"2025-01-27T13:17:21.026889","updated":"2025-01-27T13:17:21.026895","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/84dba3f1-9e31-4bf3-ba3c-348a64c622dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/84dba3f1-9e31-4bf3-ba3c-348a64c622dd/pipeline.log\">pipeline</a>"]},{"id":"a4684402-ce03-4ebe-9ac0-0e9db5e46ead","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1114.026105,"created":"2025-01-27T13:16:28.204814","updated":"2025-01-27T13:16:28.204821","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a4684402-ce03-4ebe-9ac0-0e9db5e46ead\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a4684402-ce03-4ebe-9ac0-0e9db5e46ead/pipeline.log\">pipeline</a>"]},{"id":"98cc7930-4e13-4cf9-912c-59df310ed8b7","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1163.687673,"created":"2025-01-27T13:16:28.178307","updated":"2025-01-27T13:16:28.178329","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/98cc7930-4e13-4cf9-912c-59df310ed8b7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/98cc7930-4e13-4cf9-912c-59df310ed8b7/pipeline.log\">pipeline</a>"]},{"id":"ab374871-b041-453d-8c49-0896ecdd30f9","name":"RHEL8 - 3.9-minimal","runTime":1471.696289,"created":"2025-01-27T13:35:01.332813","updated":"2025-01-27T13:35:01.332821","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab374871-b041-453d-8c49-0896ecdd30f9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ab374871-b041-453d-8c49-0896ecdd30f9/pipeline.log\">pipeline</a>"]},{"id":"1d07beef-4c30-4e29-898b-8cd25567acd6","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1081.742406,"created":"2025-01-27T13:16:28.476279","updated":"2025-01-27T13:16:28.476288","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1d07beef-4c30-4e29-898b-8cd25567acd6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1d07beef-4c30-4e29-898b-8cd25567acd6/pipeline.log\">pipeline</a>"]},{"id":"18ed5f8d-f61f-45ec-a739-766ba6cd0cc2","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":972.334617,"created":"2025-01-27T13:16:29.240910","updated":"2025-01-27T13:16:29.240917","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/18ed5f8d-f61f-45ec-a739-766ba6cd0cc2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/18ed5f8d-f61f-45ec-a739-766ba6cd0cc2/pipeline.log\">pipeline</a>"]},{"id":"afedb655-9074-46ad-93f3-87e98afcc904","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1177.423601,"created":"2025-01-27T13:16:26.622840","updated":"2025-01-27T13:16:26.622849","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/afedb655-9074-46ad-93f3-87e98afcc904\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/afedb655-9074-46ad-93f3-87e98afcc904/pipeline.log\">pipeline</a>"]},{"id":"305dc114-2c98-4b99-9af1-38503f589b3c","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1341.057387,"created":"2025-01-27T13:16:31.005378","updated":"2025-01-27T13:16:31.005384","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/305dc114-2c98-4b99-9af1-38503f589b3c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/305dc114-2c98-4b99-9af1-38503f589b3c/pipeline.log\">pipeline</a>"]},{"id":"1cccc587-21c8-40da-83d7-5ed1aa36e1f7","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1059.796172,"created":"2025-01-27T13:16:31.875661","updated":"2025-01-27T13:16:31.875670","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1cccc587-21c8-40da-83d7-5ed1aa36e1f7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1cccc587-21c8-40da-83d7-5ed1aa36e1f7/pipeline.log\">pipeline</a>"]},{"id":"6e1612c0-5e6f-445b-b8f6-9c21879405bc","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1195.375547,"created":"2025-01-27T13:16:36.260068","updated":"2025-01-27T13:16:36.260074","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6e1612c0-5e6f-445b-b8f6-9c21879405bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6e1612c0-5e6f-445b-b8f6-9c21879405bc/pipeline.log\">pipeline</a>"]},{"id":"5a7d00d8-84fd-48f9-8a91-a3acc51eff45","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1138.483875,"created":"2025-01-27T13:16:56.000708","updated":"2025-01-27T13:16:56.000713","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5a7d00d8-84fd-48f9-8a91-a3acc51eff45\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5a7d00d8-84fd-48f9-8a91-a3acc51eff45/pipeline.log\">pipeline</a>"]},{"id":"97c5c9af-239d-4f47-a55b-440e7497af3f","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1024.477634,"created":"2025-01-27T13:17:26.055748","updated":"2025-01-27T13:17:26.055757","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/97c5c9af-239d-4f47-a55b-440e7497af3f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/97c5c9af-239d-4f47-a55b-440e7497af3f/pipeline.log\">pipeline</a>"]},{"id":"43b9ba47-7960-4189-9e79-fe904832e56a","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1329.051868,"created":"2025-01-27T13:16:37.783930","updated":"2025-01-27T13:16:37.783937","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/43b9ba47-7960-4189-9e79-fe904832e56a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/43b9ba47-7960-4189-9e79-fe904832e56a/pipeline.log\">pipeline</a>"]},{"id":"df855bac-4003-45e5-85ff-fcca82844c1e","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1775.51445,"created":"2025-01-27T13:16:28.035505","updated":"2025-01-27T13:16:28.035511","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/df855bac-4003-45e5-85ff-fcca82844c1e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/df855bac-4003-45e5-85ff-fcca82844c1e/pipeline.log\">pipeline</a>"]}]} -->