### PR TITLE
switch to ubuntu-latest from ubuntu-20.04

### DIFF
--- a/.github/workflows/container-tests.yml
+++ b/.github/workflows/container-tests.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   distgen-check:
     name: "Check distgen generated files"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test]') || contains(github.event.comment.body, '[test-all]'))
@@ -53,7 +53,7 @@ jobs:
   container-tests:
     needs: distgen-check
     name: "Container tests: ${{ matrix.version }} - ${{ matrix.os_test }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: container-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true

--- a/.github/workflows/openshift-pytest.yml
+++ b/.github/workflows/openshift-pytest.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   distgen-check:
     name: "Check distgen generated files"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: |
       github.event.issue.pull_request
       && (contains(github.event.comment.body, '[test-openshift-pytest]') || contains(github.event.comment.body, '[test-all]'))
@@ -31,7 +31,7 @@ jobs:
   openshift-pytests:
     needs: distgen-check
     name: "${{ matrix.test_case }} PyTests: ${{ matrix.version }} - ${{ matrix.os_test }}"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ocp-pytest-${{ github.event.issue.number }}-${{ matrix.version }}-${{ matrix.os_test }}
       cancel-in-progress: true


### PR DESCRIPTION
Use ubuntu-latest as it is already used in postgresql-container

https://github.com/sclorg/postgresql-container/blob/master/.github/workflows/container-tests.yml#L8

dist-gen with RHEL10 support is only distributed on newer python version interpreters

