### PR TITLE
Remove deprecated --no-python-version-warning option from pip

### DIFF
--- a/examples/npm-virtualenv-uwsgi-test-app/app.sh
+++ b/examples/npm-virtualenv-uwsgi-test-app/app.sh
@@ -13,11 +13,11 @@ packages=("pip" "setuptools" "wheel")
 for pkg in ${packages[@]}; do
   # grep returns exit code 1 if the output contains only one line starting
   # with "Requirement already …" which means that the package is updated
-  python -m pip install -U --no-deps --no-python-version-warning $pkg 2>&1 | grep -Ev "^Requirement already (up-to-date|satisfied): "
+  python -m pip install -U --no-deps $pkg 2>&1 | grep -Ev "^Requirement already (up-to-date|satisfied): "
   if [ $? -eq 0 ]; then
     echo "ERROR: Failed to upgrade '$pkg' to the latest version."
     echo "Output of the pip install command is:"
-    python -m pip install -U --no-deps --no-python-version-warning $pkg
+    python -m pip install -U --no-deps $pkg
     exit 1
   fi
 done

--- a/examples/uwsgi-test-app/app.sh
+++ b/examples/uwsgi-test-app/app.sh
@@ -22,7 +22,7 @@ packages=("pip" "setuptools" "wheel")
 for pkg in ${packages[@]}; do
   # grep returns exit code 1 if the output contains only one line starting
   # with "Requirement already …" which means that the package is updated
-  python -m pip install -U --no-deps --no-python-version-warning $pkg 2>&1 | grep -Ev "^Requirement already (up-to-date|satisfied): "
+  python -m pip install -U --no-deps $pkg 2>&1 | grep -Ev "^Requirement already (up-to-date|satisfied): "
   if [ $? -eq 0 ]; then
     echo "ERROR: Failed to upgrade '$pkg' to the latest version."
     exit 1


### PR DESCRIPTION
Discussion: https://github.com/pypa/pip/issues/13154

This should have no effect. The deprecation warning produced by the new pip causes the tests to fail.





























































































































<!-- testing-farm = {"lock":"false","comment-id":"2615335032","data":[{"id":"d3253c49-bd79-48ba-800a-eb9c8741e995","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":963.005022,"created":"2025-01-27T09:55:26.616171","updated":"2025-01-27T09:55:26.616178","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d3253c49-bd79-48ba-800a-eb9c8741e995\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d3253c49-bd79-48ba-800a-eb9c8741e995/pipeline.log\">pipeline</a>"]},{"id":"e64efad9-6e04-4cb6-8137-cdc163be2b13","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1050.855373,"created":"2025-01-27T09:55:34.607498","updated":"2025-01-27T09:55:34.607505","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e64efad9-6e04-4cb6-8137-cdc163be2b13\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e64efad9-6e04-4cb6-8137-cdc163be2b13/pipeline.log\">pipeline</a>"]},{"id":"a49b9ce7-0602-49f8-a1a8-b8daf6b4b860","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1074.049427,"created":"2025-01-27T09:55:27.550158","updated":"2025-01-27T09:55:27.550165","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a49b9ce7-0602-49f8-a1a8-b8daf6b4b860\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a49b9ce7-0602-49f8-a1a8-b8daf6b4b860/pipeline.log\">pipeline</a>"]},{"id":"c0c19659-5b4e-46cd-80ec-fcc573397240","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1087.2821,"created":"2025-01-27T09:55:26.577734","updated":"2025-01-27T09:55:26.577741","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c0c19659-5b4e-46cd-80ec-fcc573397240\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c0c19659-5b4e-46cd-80ec-fcc573397240/pipeline.log\">pipeline</a>"]},{"id":"65fc10d4-726c-42ff-a6fa-2c81beb63a42","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1112.912647,"created":"2025-01-27T09:55:50.369834","updated":"2025-01-27T09:55:50.369842","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/65fc10d4-726c-42ff-a6fa-2c81beb63a42\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/65fc10d4-726c-42ff-a6fa-2c81beb63a42/pipeline.log\">pipeline</a>"]},{"id":"8955cfc1-8157-4fce-9d43-f3599176cf38","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1177.751333,"created":"2025-01-27T09:55:28.143470","updated":"2025-01-27T09:55:28.143476","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8955cfc1-8157-4fce-9d43-f3599176cf38\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8955cfc1-8157-4fce-9d43-f3599176cf38/pipeline.log\">pipeline</a>"]},{"id":"b49cc8da-dfcd-4e14-ae77-5fa893f860c4","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1196.944225,"created":"2025-01-27T09:55:27.185290","updated":"2025-01-27T09:55:27.185296","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b49cc8da-dfcd-4e14-ae77-5fa893f860c4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b49cc8da-dfcd-4e14-ae77-5fa893f860c4/pipeline.log\">pipeline</a>"]},{"id":"1d4dc81f-34bb-4369-97e8-a480da0ae3e2","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1198.473238,"created":"2025-01-27T09:55:34.405394","updated":"2025-01-27T09:55:34.405400","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1d4dc81f-34bb-4369-97e8-a480da0ae3e2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1d4dc81f-34bb-4369-97e8-a480da0ae3e2/pipeline.log\">pipeline</a>"]},{"id":"14b393dd-1152-45a8-9150-46ac5b002bbb","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1320.338371,"created":"2025-01-27T09:55:27.925530","updated":"2025-01-27T09:55:27.925537","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/14b393dd-1152-45a8-9150-46ac5b002bbb\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/14b393dd-1152-45a8-9150-46ac5b002bbb/pipeline.log\">pipeline</a>"]},{"id":"0a145daf-c72b-44bf-9df4-869a6a180dc2","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1319.490799,"created":"2025-01-27T09:55:36.044067","updated":"2025-01-27T09:55:36.044074","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a145daf-c72b-44bf-9df4-869a6a180dc2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0a145daf-c72b-44bf-9df4-869a6a180dc2/pipeline.log\">pipeline</a>"]},{"id":"7c2fe0fa-a361-4c31-9e8f-b577f504d118","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1326.259921,"created":"2025-01-27T09:55:58.311924","updated":"2025-01-27T09:55:58.311931","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7c2fe0fa-a361-4c31-9e8f-b577f504d118\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7c2fe0fa-a361-4c31-9e8f-b577f504d118/pipeline.log\">pipeline</a>"]},{"id":"5740f171-fb74-485c-884d-8b21ad292a07","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1442.182819,"created":"2025-01-27T09:55:38.517582","updated":"2025-01-27T09:55:38.517589","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5740f171-fb74-485c-884d-8b21ad292a07\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5740f171-fb74-485c-884d-8b21ad292a07/pipeline.log\">pipeline</a>"]},{"id":"2eda0c2f-02d2-4b65-903b-f3c4595502c1","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1538.692238,"created":"2025-01-27T09:55:26.572546","updated":"2025-01-27T09:55:26.572552","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2eda0c2f-02d2-4b65-903b-f3c4595502c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2eda0c2f-02d2-4b65-903b-f3c4595502c1/pipeline.log\">pipeline</a>"]},{"id":"916501b5-933a-4bc5-ab41-e279692d75ea","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1582.551279,"created":"2025-01-27T09:55:27.318518","updated":"2025-01-27T09:55:27.318524","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/916501b5-933a-4bc5-ab41-e279692d75ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/916501b5-933a-4bc5-ab41-e279692d75ea/pipeline.log\">pipeline</a>"]},{"id":"143ad6ed-84a1-426c-91c2-194939c5254e","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1613.733416,"created":"2025-01-27T09:55:26.475358","updated":"2025-01-27T09:55:26.475364","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/143ad6ed-84a1-426c-91c2-194939c5254e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/143ad6ed-84a1-426c-91c2-194939c5254e/pipeline.log\">pipeline</a>"]},{"id":"8c02673d-2889-40c5-9bca-23a5d5f9d114","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1615.834792,"created":"2025-01-27T09:56:15.573401","updated":"2025-01-27T09:56:15.573409","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c02673d-2889-40c5-9bca-23a5d5f9d114\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8c02673d-2889-40c5-9bca-23a5d5f9d114/pipeline.log\">pipeline</a>"]},{"id":"9fbeaa6a-d9e0-4c77-b09d-6ffecc129b15","name":"RHEL8 - 3.12","status":"complete","outcome":"error","runTime":1704.837054,"created":"2025-01-27T09:55:27.777641","updated":"2025-01-27T09:55:27.777647","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fbeaa6a-d9e0-4c77-b09d-6ffecc129b15\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9fbeaa6a-d9e0-4c77-b09d-6ffecc129b15/pipeline.log\">pipeline</a>"]},{"id":"0fecc722-8ee5-4244-8523-3bd1f7632d82","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1741.024688,"created":"2025-01-27T09:55:26.562979","updated":"2025-01-27T09:55:26.562986","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fecc722-8ee5-4244-8523-3bd1f7632d82\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0fecc722-8ee5-4244-8523-3bd1f7632d82/pipeline.log\">pipeline</a>"]},{"id":"f9e8ac23-135c-487e-b0eb-bb678e57d26a","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1780.960313,"created":"2025-01-27T09:56:15.419489","updated":"2025-01-27T09:56:15.419497","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f9e8ac23-135c-487e-b0eb-bb678e57d26a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f9e8ac23-135c-487e-b0eb-bb678e57d26a/pipeline.log\">pipeline</a>"]},{"id":"84370e53-80ed-4c03-a1ce-c7f34c152cb4","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1095.998541,"created":"2025-01-27T10:09:20.146902","updated":"2025-01-27T10:09:20.146911","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/84370e53-80ed-4c03-a1ce-c7f34c152cb4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/84370e53-80ed-4c03-a1ce-c7f34c152cb4/pipeline.log\">pipeline</a>"]},{"id":"8a128aea-03d2-45ef-8a53-f90b5e271354","name":"RHEL8 - 3.9-minimal","runTime":1528.009166,"created":"2025-01-27T10:12:27.853576","updated":"2025-01-27T10:12:27.853586","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8a128aea-03d2-45ef-8a53-f90b5e271354\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8a128aea-03d2-45ef-8a53-f90b5e271354/pipeline.log\">pipeline</a>"]}]} -->