### PR TITLE
Use newer branch of django-ex for newer Pythons in s2i_app_ex test.

### DIFF
--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -80,7 +80,16 @@ function test_python_s2i_app_ex_standalone() {
 }
 
 function test_python_s2i_app_ex() {
-  django_example_repo_url="https://github.com/sclorg/django-ex.git#2.2.x"
+  if [[ "${VERSION}" == *"minimal"* ]]; then
+    VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
+  fi
+  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]]; then
+    branch="4.2.x"
+  else
+    branch="2.2.x"
+  fi
+
+  django_example_repo_url="https://github.com/sclorg/django-ex.git#${branch}"
   ct_os_test_s2i_app "${IMAGE_NAME}" \
         "${django_example_repo_url}" \
         . \


### PR DESCRIPTION
Fixes: https://github.com/sclorg/s2i-python-container/issues/730


































































































































































<!-- testing-farm = {"lock":"false","comment-id":"2639682333","data":[{"id":"aeb6d136-6a54-45b2-9028-7dfa68cbc509","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":868.666432,"created":"2025-02-06T12:08:46.093349","updated":"2025-02-06T12:08:46.093359","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/aeb6d136-6a54-45b2-9028-7dfa68cbc509\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/aeb6d136-6a54-45b2-9028-7dfa68cbc509/pipeline.log\">pipeline</a>"]},{"id":"bbdd6bda-fda7-4f66-9cb9-5a570f33dae0","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":996.394177,"created":"2025-02-06T12:08:43.478412","updated":"2025-02-06T12:08:43.478422","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bbdd6bda-fda7-4f66-9cb9-5a570f33dae0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bbdd6bda-fda7-4f66-9cb9-5a570f33dae0/pipeline.log\">pipeline</a>"]},{"id":"8f77d663-44a0-4897-91dc-1481565be738","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":998.50139,"created":"2025-02-06T12:08:41.985173","updated":"2025-02-06T12:08:41.985184","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8f77d663-44a0-4897-91dc-1481565be738\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8f77d663-44a0-4897-91dc-1481565be738/pipeline.log\">pipeline</a>"]},{"id":"2bef4c7b-e6bb-4045-b8e8-e88cda69a59a","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1021.472464,"created":"2025-02-06T12:08:41.686363","updated":"2025-02-06T12:08:41.686372","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2bef4c7b-e6bb-4045-b8e8-e88cda69a59a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2bef4c7b-e6bb-4045-b8e8-e88cda69a59a/pipeline.log\">pipeline</a>"]},{"id":"62b4cb41-9fec-49ba-8828-0f70bb5da4b9","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1019.791082,"created":"2025-02-06T12:08:50.028210","updated":"2025-02-06T12:08:50.028217","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/62b4cb41-9fec-49ba-8828-0f70bb5da4b9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/62b4cb41-9fec-49ba-8828-0f70bb5da4b9/pipeline.log\">pipeline</a>"]},{"id":"32c8e347-6dbe-416b-8cc5-404470a19539","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1080.726835,"created":"2025-02-06T12:08:42.746834","updated":"2025-02-06T12:08:42.746841","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/32c8e347-6dbe-416b-8cc5-404470a19539\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/32c8e347-6dbe-416b-8cc5-404470a19539/pipeline.log\">pipeline</a>"]},{"id":"2f5d9d88-bf9e-4b38-ac70-40705e81a1be","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1114.865289,"created":"2025-02-06T12:08:41.514163","updated":"2025-02-06T12:08:41.514170","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2f5d9d88-bf9e-4b38-ac70-40705e81a1be\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2f5d9d88-bf9e-4b38-ac70-40705e81a1be/pipeline.log\">pipeline</a>"]},{"id":"360a4f22-5107-4413-bb03-903d958cc39c","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1138.863495,"created":"2025-02-06T12:08:42.423555","updated":"2025-02-06T12:08:42.423562","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/360a4f22-5107-4413-bb03-903d958cc39c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/360a4f22-5107-4413-bb03-903d958cc39c/pipeline.log\">pipeline</a>"]},{"id":"8479d007-6ad7-4a31-92dc-05f3dde18714","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1156.023856,"created":"2025-02-06T12:08:55.915473","updated":"2025-02-06T12:08:55.915479","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8479d007-6ad7-4a31-92dc-05f3dde18714\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8479d007-6ad7-4a31-92dc-05f3dde18714/pipeline.log\">pipeline</a>"]},{"id":"0df97854-727a-42fa-b1fa-66ac66554ea6","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1384.719643,"created":"2025-02-06T12:08:50.824277","updated":"2025-02-06T12:08:50.824286","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0df97854-727a-42fa-b1fa-66ac66554ea6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0df97854-727a-42fa-b1fa-66ac66554ea6/pipeline.log\">pipeline</a>"]},{"id":"2d07f9b5-b4fc-4fd8-ad7d-54666ae182fe","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1372.962378,"created":"2025-02-06T12:08:54.191994","updated":"2025-02-06T12:08:54.192002","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d07f9b5-b4fc-4fd8-ad7d-54666ae182fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2d07f9b5-b4fc-4fd8-ad7d-54666ae182fe/pipeline.log\">pipeline</a>"]},{"id":"01b60274-ec29-4d44-9527-fc52b5c86340","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1490.35383,"created":"2025-02-06T12:08:42.167489","updated":"2025-02-06T12:08:42.167495","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b60274-ec29-4d44-9527-fc52b5c86340\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/01b60274-ec29-4d44-9527-fc52b5c86340/pipeline.log\">pipeline</a>"]},{"id":"e06a8e36-dd83-47ad-8688-7f825fdbfeea","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1512.814963,"created":"2025-02-06T12:08:46.035705","updated":"2025-02-06T12:08:46.035715","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e06a8e36-dd83-47ad-8688-7f825fdbfeea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e06a8e36-dd83-47ad-8688-7f825fdbfeea/pipeline.log\">pipeline</a>"]},{"id":"82213f89-1b88-4882-9788-d1bb849de116","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1473.352388,"created":"2025-02-06T12:09:45.629534","updated":"2025-02-06T12:09:45.629544","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/82213f89-1b88-4882-9788-d1bb849de116\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/82213f89-1b88-4882-9788-d1bb849de116/pipeline.log\">pipeline</a>"]},{"id":"58699b5a-cd32-445e-821e-9028eed9dc69","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1585.452621,"created":"2025-02-06T12:08:42.298049","updated":"2025-02-06T12:08:42.298056","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58699b5a-cd32-445e-821e-9028eed9dc69\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58699b5a-cd32-445e-821e-9028eed9dc69/pipeline.log\">pipeline</a>"]},{"id":"e97dbd85-94da-4ba0-aa0c-4c994a0c3f83","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1596.251838,"created":"2025-02-06T12:08:51.346045","updated":"2025-02-06T12:08:51.346051","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e97dbd85-94da-4ba0-aa0c-4c994a0c3f83\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e97dbd85-94da-4ba0-aa0c-4c994a0c3f83/pipeline.log\">pipeline</a>"]},{"id":"4f6dff18-83f6-4bb3-a553-337178384803","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1729.188361,"created":"2025-02-06T12:08:43.399517","updated":"2025-02-06T12:08:43.399523","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f6dff18-83f6-4bb3-a553-337178384803\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f6dff18-83f6-4bb3-a553-337178384803/pipeline.log\">pipeline</a>"]},{"id":"4414c747-1a4e-453a-a2ad-d29278e996c0","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1739.48661,"created":"2025-02-06T12:08:45.017843","updated":"2025-02-06T12:08:45.017850","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4414c747-1a4e-453a-a2ad-d29278e996c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4414c747-1a4e-453a-a2ad-d29278e996c0/pipeline.log\">pipeline</a>"]},{"id":"51bc6450-9e20-4af1-984e-8bdcc9a9def2","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1756.606536,"created":"2025-02-06T12:09:32.379164","updated":"2025-02-06T12:09:32.379172","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/51bc6450-9e20-4af1-984e-8bdcc9a9def2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/51bc6450-9e20-4af1-984e-8bdcc9a9def2/pipeline.log\">pipeline</a>"]},{"id":"6f229ff5-817f-4f43-83ba-e1f848f44a80","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":971.570361,"created":"2025-02-06T12:26:12.914069","updated":"2025-02-06T12:26:12.914078","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6f229ff5-817f-4f43-83ba-e1f848f44a80\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6f229ff5-817f-4f43-83ba-e1f848f44a80/pipeline.log\">pipeline</a>"]},{"id":"87d3fb81-1628-49e0-866d-06233b4267ef","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1619.209294,"created":"2025-02-06T12:26:05.661626","updated":"2025-02-06T12:26:05.661635","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/87d3fb81-1628-49e0-866d-06233b4267ef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/87d3fb81-1628-49e0-866d-06233b4267ef/pipeline.log\">pipeline</a>"]},{"id":"e655ca64-5256-4280-a683-60942ea946f7","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1330.180356,"created":"2025-02-06T12:36:54.338652","updated":"2025-02-06T12:36:54.338662","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e655ca64-5256-4280-a683-60942ea946f7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e655ca64-5256-4280-a683-60942ea946f7/pipeline.log\">pipeline</a>"]},{"id":"5f1af7da-91bd-4ad0-8c15-0fae42e42240","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1389.550822,"created":"2025-02-06T12:36:56.005009","updated":"2025-02-06T12:36:56.005018","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f1af7da-91bd-4ad0-8c15-0fae42e42240\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f1af7da-91bd-4ad0-8c15-0fae42e42240/pipeline.log\">pipeline</a>"]},{"id":"567ec987-33f7-486f-9f68-c548c3be3173","name":"RHEL8 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1468.591787,"created":"2025-02-06T12:36:55.034260","updated":"2025-02-06T12:36:55.034268","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/567ec987-33f7-486f-9f68-c548c3be3173\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/567ec987-33f7-486f-9f68-c548c3be3173/pipeline.log\">pipeline</a>"]},{"id":"8454270c-b4a5-4248-9297-9b67e85dc5e2","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1487.081899,"created":"2025-02-06T12:36:55.414406","updated":"2025-02-06T12:36:55.414418","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8454270c-b4a5-4248-9297-9b67e85dc5e2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8454270c-b4a5-4248-9297-9b67e85dc5e2/pipeline.log\">pipeline</a>"]},{"id":"6427c75a-ab61-48c0-a50a-3f820242e3dd","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1551.538348,"created":"2025-02-06T12:36:54.467599","updated":"2025-02-06T12:36:54.467610","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6427c75a-ab61-48c0-a50a-3f820242e3dd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6427c75a-ab61-48c0-a50a-3f820242e3dd/pipeline.log\">pipeline</a>"]},{"id":"55a0225a-f307-412d-a5d8-a669b474579b","name":"RHEL9 - OpenShift 4 - 3.9","runTime":4358.569568,"created":"2025-02-06T12:36:55.475409","updated":"2025-02-06T12:36:55.475417","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"error","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/55a0225a-f307-412d-a5d8-a669b474579b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/55a0225a-f307-412d-a5d8-a669b474579b/pipeline.log\">pipeline</a>"]}]} -->