### PR TITLE
Use packaging for version comparisons

### DIFF
--- a/test/test_deploy_templates.py
+++ b/test/test_deploy_templates.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+from packaging.version import Version
 
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
@@ -21,7 +22,8 @@ DEPLOYED_PSQL_IMAGE = "quay.io/centos7/postgresql-10-centos7:centos7"
 IMAGE_TAG = "postgresql:10"
 PSQL_VERSION = "10"
 
-if VERSION == "3.11" or VERSION == "3.12":
+if Version(VERSION) >= Version("3.11"):
+    BRANCH_TO_TEST = "4.2.x"
     DEPLOYED_PSQL_IMAGE = "quay.io/sclorg/postgresql-12-c8s"
     IMAGE_TAG = "postgresql:12"
     PSQL_VERSION = "12"

--- a/test/test_imagestreams_quickstart.py
+++ b/test/test_imagestreams_quickstart.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+from packaging.version import Version
 
 from container_ci_suite.openshift import OpenShiftAPI
 from container_ci_suite.utils import check_variables
@@ -21,7 +22,7 @@ DEPLOYED_PSQL_IMAGE = "quay.io/centos7/postgresql-10-centos7:centos7"
 IMAGE_TAG = "postgresql:10"
 PSQL_VERSION = "10"
 
-if VERSION == "3.11" or VERSION == "3.12":
+if Version(VERSION) >= Version("3.11"):
     BRANCH_TO_TEST = "4.2.x"
     DEPLOYED_PSQL_IMAGE = "quay.io/sclorg/postgresql-12-c8s"
     IMAGE_TAG = "postgresql:12"

--- a/test/test_python_ex_template.py
+++ b/test/test_python_ex_template.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+from packaging.version import Version
 
 from container_ci_suite.utils import check_variables
 from container_ci_suite.openshift import OpenShiftAPI
@@ -15,7 +16,10 @@ VERSION = os.getenv("VERSION")
 IMAGE_NAME = os.getenv("IMAGE_NAME")
 OS = os.getenv("TARGET")
 
-BRANCH_TO_TEST = "2.2.x"
+if Version(VERSION) >= Version("3.11"):
+    BRANCH_TO_TEST = "4.2.x"
+else:
+    BRANCH_TO_TEST = "2.2.x"
 
 
 # Replacement with 'test_python_s2i_app_ex'


### PR DESCRIPTION
And test newer Django-ex for newer Pythons in OS.

Fixes: https://github.com/sclorg/s2i-python-container/issues/730

Related: https://github.com/sclorg/container-ci-suite/pull/105

<!-- testing-farm = {"lock":"false","comment-id":"2706312487","data":[{"id":"f6f64e5e-f7dd-43b2-81a0-71ef218177e1","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1778.781824,"created":"2025-03-19T08:43:01.656433","updated":"2025-03-19T08:43:01.656441","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6f64e5e-f7dd-43b2-81a0-71ef218177e1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6f64e5e-f7dd-43b2-81a0-71ef218177e1/pipeline.log\">pipeline</a>"]},{"id":"360b8ec4-97e3-459d-92e0-8efd773c74b9","name":"RHEL9 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"error","runTime":1404.817707,"created":"2025-03-18T09:29:17.296261","updated":"2025-03-18T09:29:17.296270","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/360b8ec4-97e3-459d-92e0-8efd773c74b9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/360b8ec4-97e3-459d-92e0-8efd773c74b9/pipeline.log\">pipeline</a>"]},{"id":"783ec0db-9907-4c2b-b5c0-5a201988c5f5","name":"RHEL9 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"error","runTime":1405.221228,"created":"2025-03-18T09:29:13.428514","updated":"2025-03-18T09:29:13.428524","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/783ec0db-9907-4c2b-b5c0-5a201988c5f5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/783ec0db-9907-4c2b-b5c0-5a201988c5f5/pipeline.log\">pipeline</a>"]},{"id":"987c75ea-0367-4966-a9e4-a1265026ab43","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1803.130118,"created":"2025-03-19T08:43:05.966395","updated":"2025-03-19T08:43:05.966403","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/987c75ea-0367-4966-a9e4-a1265026ab43\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/987c75ea-0367-4966-a9e4-a1265026ab43/pipeline.log\">pipeline</a>"]},{"id":"abf396b0-6730-489f-b68e-b20ce7a2585d","name":"RHEL8 - 3.9","runTime":1771.683399,"created":"2025-03-19T09:00:21.802395","updated":"2025-03-19T09:00:21.802401","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/abf396b0-6730-489f-b68e-b20ce7a2585d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/abf396b0-6730-489f-b68e-b20ce7a2585d/pipeline.log\">pipeline</a>"]},{"id":"e21a15aa-f044-438f-ac6f-c04c73d245d1","name":"RHEL8 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"error","runTime":1578.088362,"created":"2025-03-18T09:29:13.297054","updated":"2025-03-18T09:29:13.297062","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e21a15aa-f044-438f-ac6f-c04c73d245d1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e21a15aa-f044-438f-ac6f-c04c73d245d1/pipeline.log\">pipeline</a>"]},{"id":"ad2f2e12-6c02-4719-9b98-da6613ea337d","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1550.384088,"created":"2025-03-19T08:43:48.041319","updated":"2025-03-19T08:43:48.041326","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad2f2e12-6c02-4719-9b98-da6613ea337d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ad2f2e12-6c02-4719-9b98-da6613ea337d/pipeline.log\">pipeline</a>"]},{"id":"16595fff-d7b5-4a4c-bf7d-1d2e5d2b5352","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1501.488811,"created":"2025-03-19T08:43:01.194471","updated":"2025-03-19T08:43:01.194478","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/16595fff-d7b5-4a4c-bf7d-1d2e5d2b5352\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/16595fff-d7b5-4a4c-bf7d-1d2e5d2b5352/pipeline.log\">pipeline</a>"]},{"id":"b6078c1f-9223-41dc-9420-c9cc0239c3f8","name":"RHEL8 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"error","runTime":1534.432643,"created":"2025-03-18T09:29:14.410417","updated":"2025-03-18T09:29:14.410425","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6078c1f-9223-41dc-9420-c9cc0239c3f8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6078c1f-9223-41dc-9420-c9cc0239c3f8/pipeline.log\">pipeline</a>"]},{"id":"3e1d6258-04ca-4d2d-b93e-1ecab9207178","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1540.734683,"created":"2025-03-19T08:43:00.944731","updated":"2025-03-19T08:43:00.944739","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e1d6258-04ca-4d2d-b93e-1ecab9207178\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e1d6258-04ca-4d2d-b93e-1ecab9207178/pipeline.log\">pipeline</a>"]},{"id":"0760b51f-ac67-450b-8dfa-02406d399735","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":929.644619,"created":"2025-03-19T08:43:00.491475","updated":"2025-03-19T08:43:00.491483","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0760b51f-ac67-450b-8dfa-02406d399735\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0760b51f-ac67-450b-8dfa-02406d399735/pipeline.log\">pipeline</a>"]},{"id":"b4a8e0b0-095b-4d78-8443-0d8a294555e9","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":932.529619,"created":"2025-03-19T08:43:02.821902","updated":"2025-03-19T08:43:02.821909","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b4a8e0b0-095b-4d78-8443-0d8a294555e9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b4a8e0b0-095b-4d78-8443-0d8a294555e9/pipeline.log\">pipeline</a>"]},{"id":"7e92a9f4-b99e-4068-88be-e89170632cf3","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1092.000874,"created":"2025-03-19T08:43:11.965485","updated":"2025-03-19T08:43:11.965492","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7e92a9f4-b99e-4068-88be-e89170632cf3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7e92a9f4-b99e-4068-88be-e89170632cf3/pipeline.log\">pipeline</a>"]},{"id":"d014b08a-c789-48ff-b731-c6cef32e1059","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":916.34037,"created":"2025-03-19T08:43:34.292421","updated":"2025-03-19T08:43:34.292427","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d014b08a-c789-48ff-b731-c6cef32e1059\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d014b08a-c789-48ff-b731-c6cef32e1059/pipeline.log\">pipeline</a>"]},{"id":"e31ffd02-2d5d-4718-8e84-435c89aa31ab","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1017.439629,"created":"2025-03-19T08:43:02.617458","updated":"2025-03-19T08:43:02.617465","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e31ffd02-2d5d-4718-8e84-435c89aa31ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e31ffd02-2d5d-4718-8e84-435c89aa31ab/pipeline.log\">pipeline</a>"]},{"id":"1d3af631-a595-486f-8539-4e84f893aee4","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1016.72689,"created":"2025-03-19T08:59:14.876873","updated":"2025-03-19T08:59:14.876879","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1d3af631-a595-486f-8539-4e84f893aee4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1d3af631-a595-486f-8539-4e84f893aee4/pipeline.log\">pipeline</a>"]},{"id":"b037b688-630d-40b1-85a3-ba96392c4b76","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":951.564335,"created":"2025-03-19T08:42:59.121437","updated":"2025-03-19T08:42:59.121444","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b037b688-630d-40b1-85a3-ba96392c4b76\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b037b688-630d-40b1-85a3-ba96392c4b76/pipeline.log\">pipeline</a>"]},{"id":"c99caedf-5645-41f8-8c21-e6232aa56238","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1205.873845,"created":"2025-03-19T08:43:08.448985","updated":"2025-03-19T08:43:08.448991","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c99caedf-5645-41f8-8c21-e6232aa56238\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c99caedf-5645-41f8-8c21-e6232aa56238/pipeline.log\">pipeline</a>"]},{"id":"b8bba7f9-43b9-4089-b4e7-83481f913d44","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"error","runTime":535.343882,"created":"2025-03-19T08:43:11.034220","updated":"2025-03-19T08:43:11.034226","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b8bba7f9-43b9-4089-b4e7-83481f913d44\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b8bba7f9-43b9-4089-b4e7-83481f913d44/pipeline.log\">pipeline</a>"]},{"id":"a671d298-8068-44de-814f-ef05433b3dcd","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1636.219623,"created":"2025-03-19T08:43:10.214810","updated":"2025-03-19T08:43:10.214816","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a671d298-8068-44de-814f-ef05433b3dcd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a671d298-8068-44de-814f-ef05433b3dcd/pipeline.log\">pipeline</a>"]},{"id":"4966e1b5-4062-49f6-a0b8-1a3702de3169","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1616.184227,"created":"2025-03-19T08:42:59.298685","updated":"2025-03-19T08:42:59.298693","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4966e1b5-4062-49f6-a0b8-1a3702de3169\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4966e1b5-4062-49f6-a0b8-1a3702de3169/pipeline.log\">pipeline</a>"]},{"id":"78c21c9f-59c5-42f5-a78e-24b31b937734","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1546.286482,"created":"2025-03-19T09:02:08.226694","updated":"2025-03-19T09:02:08.226701","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/78c21c9f-59c5-42f5-a78e-24b31b937734\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/78c21c9f-59c5-42f5-a78e-24b31b937734/pipeline.log\">pipeline</a>"]},{"id":"36902393-0be3-4f58-8e1d-80e088b38c6e","name":"RHEL9 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1435.303619,"created":"2025-03-19T08:58:48.085035","updated":"2025-03-19T08:58:48.085041","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/36902393-0be3-4f58-8e1d-80e088b38c6e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/36902393-0be3-4f58-8e1d-80e088b38c6e/pipeline.log\">pipeline</a>"]},{"id":"14bf52b1-e1c9-4c0a-8248-7f94250792c1","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1533.46327,"created":"2025-03-19T09:01:30.624718","updated":"2025-03-19T09:01:30.624726","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14bf52b1-e1c9-4c0a-8248-7f94250792c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14bf52b1-e1c9-4c0a-8248-7f94250792c1/pipeline.log\">pipeline</a>"]},{"id":"d82dad31-f567-49c7-b75b-ac04b4e4bab5","name":"RHEL8 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1470.25541,"created":"2025-03-19T08:52:44.461525","updated":"2025-03-19T08:52:44.461533","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d82dad31-f567-49c7-b75b-ac04b4e4bab5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d82dad31-f567-49c7-b75b-ac04b4e4bab5/pipeline.log\">pipeline</a>"]},{"id":"b079d2d3-df6e-4ee2-870b-9d2c450d4894","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1565.153941,"created":"2025-03-19T09:01:53.359314","updated":"2025-03-19T09:01:53.359320","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b079d2d3-df6e-4ee2-870b-9d2c450d4894\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b079d2d3-df6e-4ee2-870b-9d2c450d4894/pipeline.log\">pipeline</a>"]},{"id":"90641e0f-a93e-484b-a3ec-02bd61d493e7","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1380.170383,"created":"2025-03-19T08:59:23.654829","updated":"2025-03-19T08:59:23.654835","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/90641e0f-a93e-484b-a3ec-02bd61d493e7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/90641e0f-a93e-484b-a3ec-02bd61d493e7/pipeline.log\">pipeline</a>"]},{"id":"991586ca-8e84-42b2-a0ba-58d6fb7d049a","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":880.618544,"created":"2025-03-19T08:43:06.281164","updated":"2025-03-19T08:43:06.281174","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/991586ca-8e84-42b2-a0ba-58d6fb7d049a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/991586ca-8e84-42b2-a0ba-58d6fb7d049a/pipeline.log\">pipeline</a>"]},{"id":"6890ad68-3e67-4b77-b2be-63c655f0308c","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1006.140789,"created":"2025-03-19T08:43:32.523644","updated":"2025-03-19T08:43:32.523650","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6890ad68-3e67-4b77-b2be-63c655f0308c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6890ad68-3e67-4b77-b2be-63c655f0308c/pipeline.log\">pipeline</a>"]},{"id":"057ab970-72d3-483e-a09b-3ffff7dd1647","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1171.763868,"created":"2025-03-19T08:43:02.318998","updated":"2025-03-19T08:43:02.319004","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/057ab970-72d3-483e-a09b-3ffff7dd1647\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/057ab970-72d3-483e-a09b-3ffff7dd1647/pipeline.log\">pipeline</a>"]},{"id":"ca931f08-3042-4739-b7a1-699e431e8898","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1427.715026,"created":"2025-03-19T08:42:59.968520","updated":"2025-03-19T08:42:59.968526","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca931f08-3042-4739-b7a1-699e431e8898\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ca931f08-3042-4739-b7a1-699e431e8898/pipeline.log\">pipeline</a>"]},{"id":"f4b47ac8-efd6-40c3-824e-f7457f3b87fa","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1795.113193,"created":"2025-03-19T08:43:09.874490","updated":"2025-03-19T08:43:09.874497","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4b47ac8-efd6-40c3-824e-f7457f3b87fa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4b47ac8-efd6-40c3-824e-f7457f3b87fa/pipeline.log\">pipeline</a>"]}]} -->