### PR TITLE
Fixing OpenShift 4 tests

### DIFF
--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -109,12 +109,14 @@ django-postgresql-persistent.json"
   if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]]; then
     postgresql_image="quay.io/sclorg/postgresql-12-c8s|postgresql:12"
     postgresql_version="12"
+    branch="4.2.x"
   else
     postgresql_image="quay.io/centos7/postgresql-10-centos7:centos7|postgresql:10"
     postgresql_version="10"
+    branch="2.2.x"
   fi
   for template in $EPHEMERAL_TEMPLATES; do
-      branch="2.2.x"
+
       ct_os_test_template_app "$IMAGE_NAME" \
                               "https://raw.githubusercontent.com/sclorg/django-ex/${branch}/openshift/templates/${template}" \
                               python \


### PR DESCRIPTION
Use proper branch for testing 'test_python_s2i_templates'
in case of VERSIONS '3.11' and '3.12' use branch '4.2.X' otherwise use branch '2.2.X'

Fixes: #733

<!-- testing-farm = {"lock":"false","comment-id":"2740133325","data":[{"id":"6ff9f6a7-f41d-4036-9d8d-a0ac4d4da238","name":"RHEL10 - 3.12-minimal","runTime":1319.984302,"created":"2025-03-20T13:16:02.340636","updated":"2025-03-20T13:16:02.340645","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ff9f6a7-f41d-4036-9d8d-a0ac4d4da238\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ff9f6a7-f41d-4036-9d8d-a0ac4d4da238/pipeline.log\">pipeline</a>"]},{"id":"09d5f7ba-eadf-42c2-83a3-98bb4a39a7d6","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":839.98159,"created":"2025-03-20T11:33:24.386960","updated":"2025-03-20T11:33:24.386966","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/09d5f7ba-eadf-42c2-83a3-98bb4a39a7d6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/09d5f7ba-eadf-42c2-83a3-98bb4a39a7d6/pipeline.log\">pipeline</a>"]},{"id":"84b6a0c7-ac23-4f5a-9894-bad8c39451fd","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":902.523028,"created":"2025-03-20T11:33:44.847211","updated":"2025-03-20T11:33:44.847218","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/84b6a0c7-ac23-4f5a-9894-bad8c39451fd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/84b6a0c7-ac23-4f5a-9894-bad8c39451fd/pipeline.log\">pipeline</a>"]},{"id":"7dff4a58-1ec3-4a7b-bfc0-58252cd53e8e","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":902.327747,"created":"2025-03-20T11:33:50.971483","updated":"2025-03-20T11:33:50.971490","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7dff4a58-1ec3-4a7b-bfc0-58252cd53e8e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7dff4a58-1ec3-4a7b-bfc0-58252cd53e8e/pipeline.log\">pipeline</a>"]},{"id":"493727dd-0173-4536-9108-4432042a2c63","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":909.914512,"created":"2025-03-20T11:33:25.980398","updated":"2025-03-20T11:33:25.980404","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/493727dd-0173-4536-9108-4432042a2c63\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/493727dd-0173-4536-9108-4432042a2c63/pipeline.log\">pipeline</a>"]},{"id":"a46f7aa3-9f48-4fb7-8fe0-11d76abb0826","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":977.806998,"created":"2025-03-20T11:33:25.924487","updated":"2025-03-20T11:33:25.924495","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a46f7aa3-9f48-4fb7-8fe0-11d76abb0826\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a46f7aa3-9f48-4fb7-8fe0-11d76abb0826/pipeline.log\">pipeline</a>"]},{"id":"757db119-9ec3-41d9-802d-8737afa916b4","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1000.718991,"created":"2025-03-20T11:33:28.185738","updated":"2025-03-20T11:33:28.185744","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/757db119-9ec3-41d9-802d-8737afa916b4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/757db119-9ec3-41d9-802d-8737afa916b4/pipeline.log\">pipeline</a>"]},{"id":"e3d0d19e-ab35-46c8-ba10-73177c0f23c8","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1000.58862,"created":"2025-03-20T11:33:35.021977","updated":"2025-03-20T11:33:35.021984","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e3d0d19e-ab35-46c8-ba10-73177c0f23c8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e3d0d19e-ab35-46c8-ba10-73177c0f23c8/pipeline.log\">pipeline</a>"]},{"id":"0611f252-7b0d-436b-8639-58d0e92c129b","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1046.362212,"created":"2025-03-20T11:33:42.777166","updated":"2025-03-20T11:33:42.777172","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0611f252-7b0d-436b-8639-58d0e92c129b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0611f252-7b0d-436b-8639-58d0e92c129b/pipeline.log\">pipeline</a>"]},{"id":"297018a6-3e4c-4857-bd2e-0d0ca52020c1","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1062.983804,"created":"2025-03-20T11:33:45.941605","updated":"2025-03-20T11:33:45.941612","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/297018a6-3e4c-4857-bd2e-0d0ca52020c1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/297018a6-3e4c-4857-bd2e-0d0ca52020c1/pipeline.log\">pipeline</a>"]},{"id":"826b3182-0d0d-4261-bc9b-ec68216519e0","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1200.44744,"created":"2025-03-20T11:33:25.114154","updated":"2025-03-20T11:33:25.114159","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/826b3182-0d0d-4261-bc9b-ec68216519e0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/826b3182-0d0d-4261-bc9b-ec68216519e0/pipeline.log\">pipeline</a>"]},{"id":"f7a2c837-74b0-4ab8-bbe5-f23f119f6ae3","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1328.366179,"created":"2025-03-20T11:33:28.560681","updated":"2025-03-20T11:33:28.560687","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7a2c837-74b0-4ab8-bbe5-f23f119f6ae3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7a2c837-74b0-4ab8-bbe5-f23f119f6ae3/pipeline.log\">pipeline</a>"]},{"id":"5affa78c-982f-4a08-8b31-9a9af4736c60","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1470.83338,"created":"2025-03-20T11:33:35.921060","updated":"2025-03-20T11:33:35.921068","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5affa78c-982f-4a08-8b31-9a9af4736c60\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5affa78c-982f-4a08-8b31-9a9af4736c60/pipeline.log\">pipeline</a>"]},{"id":"1e92f86f-e0fb-4ceb-ab70-1f3f152fcbff","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":1476.358773,"created":"2025-03-20T11:33:37.549856","updated":"2025-03-20T11:33:37.549862","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e92f86f-e0fb-4ceb-ab70-1f3f152fcbff\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1e92f86f-e0fb-4ceb-ab70-1f3f152fcbff/pipeline.log\">pipeline</a>"]},{"id":"14c77db6-c4fa-45c5-8a10-43fa431614e8","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1492.842406,"created":"2025-03-20T11:33:34.030581","updated":"2025-03-20T11:33:34.030588","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/14c77db6-c4fa-45c5-8a10-43fa431614e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/14c77db6-c4fa-45c5-8a10-43fa431614e8/pipeline.log\">pipeline</a>"]},{"id":"644beb6c-50ae-45a8-a621-5bea06fc0224","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1530.927483,"created":"2025-03-20T11:33:27.093417","updated":"2025-03-20T11:33:27.093426","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/644beb6c-50ae-45a8-a621-5bea06fc0224\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/644beb6c-50ae-45a8-a621-5bea06fc0224/pipeline.log\">pipeline</a>"]},{"id":"b4d60469-43d7-41b0-8c51-399f81e299fe","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1527.655339,"created":"2025-03-20T11:33:38.789381","updated":"2025-03-20T11:33:38.789387","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4d60469-43d7-41b0-8c51-399f81e299fe\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b4d60469-43d7-41b0-8c51-399f81e299fe/pipeline.log\">pipeline</a>"]},{"id":"bf685322-27e5-4858-9065-4e06546b9610","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1708.740439,"created":"2025-03-20T11:33:26.805937","updated":"2025-03-20T11:33:26.805943","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf685322-27e5-4858-9065-4e06546b9610\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf685322-27e5-4858-9065-4e06546b9610/pipeline.log\">pipeline</a>"]},{"id":"3fd8dbb6-912c-4e6e-8451-dd6b307923da","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1738.41579,"created":"2025-03-20T11:33:24.274014","updated":"2025-03-20T11:33:24.274019","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fd8dbb6-912c-4e6e-8451-dd6b307923da\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3fd8dbb6-912c-4e6e-8451-dd6b307923da/pipeline.log\">pipeline</a>"]},{"id":"308d71a1-c937-4b24-b4ce-bd51162b7e96","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1752.026612,"created":"2025-03-20T11:33:43.776984","updated":"2025-03-20T11:33:43.776990","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/308d71a1-c937-4b24-b4ce-bd51162b7e96\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/308d71a1-c937-4b24-b4ce-bd51162b7e96/pipeline.log\">pipeline</a>"]},{"id":"d4acf79d-be9a-4688-a66a-11c67553a88c","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1483.854925,"created":"2025-03-20T11:39:55.250370","updated":"2025-03-20T11:39:55.250377","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4acf79d-be9a-4688-a66a-11c67553a88c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d4acf79d-be9a-4688-a66a-11c67553a88c/pipeline.log\">pipeline</a>"]},{"id":"deeef898-f765-4729-b4d0-f28580ded59a","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1195.956774,"created":"2025-03-20T11:47:49.111595","updated":"2025-03-20T11:47:49.111604","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/deeef898-f765-4729-b4d0-f28580ded59a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/deeef898-f765-4729-b4d0-f28580ded59a/pipeline.log\">pipeline</a>"]},{"id":"c3d126ec-2f37-42c1-bdfe-014a016c40f6","name":"RHEL8 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1558.791669,"created":"2025-03-20T11:54:44.940567","updated":"2025-03-20T11:54:44.940573","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3d126ec-2f37-42c1-bdfe-014a016c40f6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3d126ec-2f37-42c1-bdfe-014a016c40f6/pipeline.log\">pipeline</a>"]},{"id":"32cc40ac-f37b-4dda-af51-1648b3f9bada","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1558.727336,"created":"2025-03-20T11:54:46.670133","updated":"2025-03-20T11:54:46.670142","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32cc40ac-f37b-4dda-af51-1648b3f9bada\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32cc40ac-f37b-4dda-af51-1648b3f9bada/pipeline.log\">pipeline</a>"]},{"id":"d1eabd23-ab48-44c9-beb6-4ca3cbe5ff8a","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1541.464295,"created":"2025-03-20T11:54:51.001027","updated":"2025-03-20T11:54:51.001033","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1eabd23-ab48-44c9-beb6-4ca3cbe5ff8a\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d1eabd23-ab48-44c9-beb6-4ca3cbe5ff8a/pipeline.log\">pipeline</a>"]},{"id":"6e6b8c1b-a662-4667-b76a-bb0ba5c1495d","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1576.24924,"created":"2025-03-20T11:54:51.163778","updated":"2025-03-20T11:54:51.163785","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e6b8c1b-a662-4667-b76a-bb0ba5c1495d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e6b8c1b-a662-4667-b76a-bb0ba5c1495d/pipeline.log\">pipeline</a>"]},{"id":"109b9dd5-fdc2-4137-839b-b1d3a6147a77","name":"RHEL9 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1579.043633,"created":"2025-03-20T11:54:47.189906","updated":"2025-03-20T11:54:47.189913","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/109b9dd5-fdc2-4137-839b-b1d3a6147a77\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/109b9dd5-fdc2-4137-839b-b1d3a6147a77/pipeline.log\">pipeline</a>"]},{"id":"bf498de8-9b48-40ff-bdca-f2bed0a112cc","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1717.904812,"created":"2025-03-20T11:54:44.634097","updated":"2025-03-20T11:54:44.634102","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf498de8-9b48-40ff-bdca-f2bed0a112cc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bf498de8-9b48-40ff-bdca-f2bed0a112cc/pipeline.log\">pipeline</a>"]}]} -->