### PR TITLE
Switch ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-push:
     if: github.repository_owner == 'sclorg'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The current version has been retired
https://ubuntu.com/about/release-cycle

<!-- testing-farm = {"lock":"false","comment-id":"2823261669","data":[{"id":"6e64e26e-1b7a-4176-9c18-bb6f49ea458b","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":907.467723,"created":"2025-04-23T06:42:17.570367","updated":"2025-04-23T06:42:17.570375","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6e64e26e-1b7a-4176-9c18-bb6f49ea458b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6e64e26e-1b7a-4176-9c18-bb6f49ea458b/pipeline.log\">pipeline</a>"]},{"id":"ddc100e9-154d-431e-a4f6-7446bec53783","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":901.837321,"created":"2025-04-23T06:42:20.386071","updated":"2025-04-23T06:42:20.386077","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ddc100e9-154d-431e-a4f6-7446bec53783\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ddc100e9-154d-431e-a4f6-7446bec53783/pipeline.log\">pipeline</a>"]},{"id":"1f805c55-fece-4bf7-b205-b2ee1c8637ab","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":969.638319,"created":"2025-04-23T06:41:58.875437","updated":"2025-04-23T06:41:58.875446","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1f805c55-fece-4bf7-b205-b2ee1c8637ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1f805c55-fece-4bf7-b205-b2ee1c8637ab/pipeline.log\">pipeline</a>"]},{"id":"6e5fee76-0cae-43cb-ae2e-6910f4c54979","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"error","runTime":1037.50125,"created":"2025-04-23T06:42:00.527220","updated":"2025-04-23T06:42:00.527225","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e5fee76-0cae-43cb-ae2e-6910f4c54979\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e5fee76-0cae-43cb-ae2e-6910f4c54979/pipeline.log\">pipeline</a>"]},{"id":"0b23bcb2-d52e-4808-8f48-1347e7fe1d06","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1030.957863,"created":"2025-04-23T06:42:01.133625","updated":"2025-04-23T06:42:01.133631","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/0b23bcb2-d52e-4808-8f48-1347e7fe1d06\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/0b23bcb2-d52e-4808-8f48-1347e7fe1d06/pipeline.log\">pipeline</a>"]},{"id":"12901613-b759-40f4-9762-c4056cb72940","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1051.269535,"created":"2025-04-23T06:41:59.121175","updated":"2025-04-23T06:41:59.121181","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/12901613-b759-40f4-9762-c4056cb72940\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/12901613-b759-40f4-9762-c4056cb72940/pipeline.log\">pipeline</a>"]},{"id":"92a12c41-42f2-4af0-9dfd-b0699b312a23","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1071.128776,"created":"2025-04-23T06:41:59.686925","updated":"2025-04-23T06:41:59.686931","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/92a12c41-42f2-4af0-9dfd-b0699b312a23\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/92a12c41-42f2-4af0-9dfd-b0699b312a23/pipeline.log\">pipeline</a>"]},{"id":"8fc35109-ce03-498a-8258-70262de8ea05","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1078.627693,"created":"2025-04-23T06:42:05.875789","updated":"2025-04-23T06:42:05.875795","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8fc35109-ce03-498a-8258-70262de8ea05\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8fc35109-ce03-498a-8258-70262de8ea05/pipeline.log\">pipeline</a>"]},{"id":"4ba2ed24-5c35-4b12-b037-eeacfe33d477","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1060.795346,"created":"2025-04-23T06:42:09.114078","updated":"2025-04-23T06:42:09.114084","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4ba2ed24-5c35-4b12-b037-eeacfe33d477\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4ba2ed24-5c35-4b12-b037-eeacfe33d477/pipeline.log\">pipeline</a>"]},{"id":"d74e6c56-2499-4f0e-b944-b557b41804fd","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1128.839209,"created":"2025-04-23T06:41:59.034403","updated":"2025-04-23T06:41:59.034409","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d74e6c56-2499-4f0e-b944-b557b41804fd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d74e6c56-2499-4f0e-b944-b557b41804fd/pipeline.log\">pipeline</a>"]},{"id":"f77830ab-057c-4e04-958d-1f36bc7641b1","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1290.792207,"created":"2025-04-23T06:42:01.355296","updated":"2025-04-23T06:42:01.355302","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f77830ab-057c-4e04-958d-1f36bc7641b1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f77830ab-057c-4e04-958d-1f36bc7641b1/pipeline.log\">pipeline</a>"]},{"id":"d98e67dd-284f-4c65-a76c-441e4edf9dd1","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1301.879319,"created":"2025-04-23T06:41:59.462698","updated":"2025-04-23T06:41:59.462704","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d98e67dd-284f-4c65-a76c-441e4edf9dd1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d98e67dd-284f-4c65-a76c-441e4edf9dd1/pipeline.log\">pipeline</a>"]},{"id":"d8bb70dc-789a-4b74-b199-4f423eae1381","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1416.672113,"created":"2025-04-23T06:42:06.894348","updated":"2025-04-23T06:42:06.894353","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8bb70dc-789a-4b74-b199-4f423eae1381\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d8bb70dc-789a-4b74-b199-4f423eae1381/pipeline.log\">pipeline</a>"]},{"id":"e7d28f70-17b1-4a6a-92a6-7b0ab9695a5b","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1564.317708,"created":"2025-04-23T06:42:05.653762","updated":"2025-04-23T06:42:05.653768","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7d28f70-17b1-4a6a-92a6-7b0ab9695a5b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e7d28f70-17b1-4a6a-92a6-7b0ab9695a5b/pipeline.log\">pipeline</a>"]},{"id":"c776a57f-b206-4411-a01a-8d2601fa17f2","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1590.773621,"created":"2025-04-23T06:41:58.869949","updated":"2025-04-23T06:41:58.869957","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c776a57f-b206-4411-a01a-8d2601fa17f2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c776a57f-b206-4411-a01a-8d2601fa17f2/pipeline.log\">pipeline</a>"]},{"id":"2e8e9ac3-83df-426a-9393-855de5fa66ed","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1849.01163,"created":"2025-04-23T06:42:18.904646","updated":"2025-04-23T06:42:18.904652","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e8e9ac3-83df-426a-9393-855de5fa66ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2e8e9ac3-83df-426a-9393-855de5fa66ed/pipeline.log\">pipeline</a>"]},{"id":"6de68ced-43af-4b58-a9b1-dd2996dc2e67","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1644.666691,"created":"2025-04-23T06:45:44.342793","updated":"2025-04-23T06:45:44.342801","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6de68ced-43af-4b58-a9b1-dd2996dc2e67\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6de68ced-43af-4b58-a9b1-dd2996dc2e67/pipeline.log\">pipeline</a>"]},{"id":"9feaaeaa-c20e-4f8a-a388-50b7dec927ac","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1945.853778,"created":"2025-04-23T06:42:01.001724","updated":"2025-04-23T06:42:01.001732","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9feaaeaa-c20e-4f8a-a388-50b7dec927ac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9feaaeaa-c20e-4f8a-a388-50b7dec927ac/pipeline.log\">pipeline</a>"]},{"id":"996e34a8-e697-4e57-b937-00a6f9c71824","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1922.059648,"created":"2025-04-23T06:59:40.497066","updated":"2025-04-23T06:59:40.497072","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/996e34a8-e697-4e57-b937-00a6f9c71824\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/996e34a8-e697-4e57-b937-00a6f9c71824/pipeline.log\">pipeline</a>"]},{"id":"46620775-d7bd-4635-b4ac-3b5e4a4f00d8","name":"RHEL9 - 3.11","runTime":1991.030665,"created":"2025-04-23T06:59:50.750506","updated":"2025-04-23T06:59:50.750512","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46620775-d7bd-4635-b4ac-3b5e4a4f00d8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46620775-d7bd-4635-b4ac-3b5e4a4f00d8/pipeline.log\">pipeline</a>"]}]} -->