### PR TITLE
Update github action with testing version 3.12, and 3.12-minimal

### DIFF
--- a/.github/workflows/openshift-pytest.yml
+++ b/.github/workflows/openshift-pytest.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "3.8", "3.9", "3.11" ]
+        version: [ "3.8", "3.9", "3.11", "3.12", "3.12-minimal" ]
         os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-pytest" ]
 

--- a/.github/workflows/openshift-tests.yml
+++ b/.github/workflows/openshift-tests.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "3.8", "3.9", "3.11", "3.12" ]
+        version: [ "3.8", "3.9", "3.11", "3.12", "3.12-minimal" ]
         os_test: [ "rhel8", "rhel9", "rhel10" ]
         test_case: [ "openshift-4" ]
 


### PR DESCRIPTION
Update github action with testing version 3.12, and 3.12-minimal

by PyTest suite used in OpenShift 4.
The pull request does not modify python code or test suite itself at all.

The next pull request will add RHEL10 imagestreams that should be used by this pull request.
