### PR TITLE
Fix RHEL8 and OpenShift-4 tests

### DIFF
--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -12,7 +12,7 @@ source "${THISDIR}/test-lib.sh"
 source "${THISDIR}/test-lib-openshift.sh"
 
 function ct_pull_or_import_postgresql() {
-  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]] || [[ "${VERSION}" == "3.12-minimal" ]]; then
+  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.11-minimal" ]] || [[ "${VERSION}" == "3.12" ]] || [[ "${VERSION}" == "3.12-minimal" ]]; then
     postgresql_image="quay.io/sclorg/postgresql-12-c8s"
     image_short="postgresql:12"
     image_tag="${image_short}"
@@ -28,7 +28,7 @@ function ct_pull_or_import_postgresql() {
     # Exit in case of failure, because postgresql container is mandatory
     ct_pull_image "${postgresql_image}" "true"
   else
-    # Import postgresql-10-centos7 image before running tests on CVP
+    # Import postgresql-10-c8s image before running tests on CVP
     oc import-image "${image_short}:latest" --from="${postgresql_image}:latest" --insecure=true --confirm
     # Tag postgresql image to "postgresql:10" which is expected by test suite
     oc tag "${image_short}:latest" "${image_tag}"
@@ -37,6 +37,10 @@ function ct_pull_or_import_postgresql() {
 
 # Check the imagestream
 function test_python_imagestream() {
+  if [[ "${VERSIONS}" == "3.9-minimal" ]] || [[ "${VERSIONS}" == "3.11-minimal" ]]; then
+    echo "Skipping tests for ${VERSIONS}. It is not supported in Container Catalog. Imagestreams do not exist for them."
+    return 0
+  fi
   local tag="-ubi8"
   if [ "${OS}" == "rhel9" ]; then
     tag="-ubi9"


### PR DESCRIPTION
Pull proper image for 3.11-minimal image.

Python 3.9-minimal and 3.11-minimal images
do not exists in container catalog. So skipping
`test_python_imagestream` test.

The NightlyBuild tests are failing on RHEL8 and OpenShift 4 tests for 3.9-minimal and 3.11-minimal versions.

<!-- testing-farm = {"lock":"false","comment-id":"2996011252","data":[{"id":"f7a1af24-f890-45d9-a749-95dffd7e622e","name":"RHEL10 - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1283.795752,"created":"2025-06-23T10:53:02.220927","updated":"2025-06-23T10:53:02.220933","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7a1af24-f890-45d9-a749-95dffd7e622e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f7a1af24-f890-45d9-a749-95dffd7e622e/pipeline.log\">pipeline</a>"]},{"id":"6bdc3a09-f0aa-45d1-8822-89cc816f6e78","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1452.681049,"created":"2025-06-23T10:53:01.502577","updated":"2025-06-23T10:53:01.502587","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bdc3a09-f0aa-45d1-8822-89cc816f6e78\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bdc3a09-f0aa-45d1-8822-89cc816f6e78/pipeline.log\">pipeline</a>"]},{"id":"3cb54dd2-8dc3-4100-9e9f-2d0bbd793077","name":"RHEL9 - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1561.81374,"created":"2025-06-23T10:53:01.889537","updated":"2025-06-23T10:53:01.889544","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cb54dd2-8dc3-4100-9e9f-2d0bbd793077\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3cb54dd2-8dc3-4100-9e9f-2d0bbd793077/pipeline.log\">pipeline</a>"]},{"id":"9359f211-ab2e-41d7-b075-33e89758efc1","name":"RHEL9 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1626.524059,"created":"2025-06-23T10:53:03.198278","updated":"2025-06-23T10:53:03.198283","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9359f211-ab2e-41d7-b075-33e89758efc1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9359f211-ab2e-41d7-b075-33e89758efc1/pipeline.log\">pipeline</a>"]},{"id":"ade21de9-f77d-4089-b03c-99cf33234e30","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1595.213534,"created":"2025-06-23T10:53:02.207314","updated":"2025-06-23T10:53:02.207321","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ade21de9-f77d-4089-b03c-99cf33234e30\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ade21de9-f77d-4089-b03c-99cf33234e30/pipeline.log\">pipeline</a>"]},{"id":"6fa5619f-b997-42f5-99d3-35c61804f8d9","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1567.822193,"created":"2025-06-23T10:53:00.854961","updated":"2025-06-23T10:53:00.854969","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fa5619f-b997-42f5-99d3-35c61804f8d9\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6fa5619f-b997-42f5-99d3-35c61804f8d9/pipeline.log\">pipeline</a>"]},{"id":"9eae7f06-3839-45cf-adaa-b287e6382278","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1672.3478,"created":"2025-06-23T10:53:01.529048","updated":"2025-06-23T10:53:01.529055","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9eae7f06-3839-45cf-adaa-b287e6382278\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9eae7f06-3839-45cf-adaa-b287e6382278/pipeline.log\">pipeline</a>"]},{"id":"f44d7c9c-08de-4c01-bdbc-4a23cb5472f1","name":"RHEL10 - PyTest - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1481.942069,"created":"2025-06-23T11:43:01.427983","updated":"2025-06-23T11:43:01.427992","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f44d7c9c-08de-4c01-bdbc-4a23cb5472f1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f44d7c9c-08de-4c01-bdbc-4a23cb5472f1/pipeline.log\">pipeline</a>"]},{"id":"6e908949-128d-4a92-92fe-ae7a2b022e04","name":"RHEL8 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1919.453738,"created":"2025-06-23T11:43:00.436215","updated":"2025-06-23T11:43:00.436224","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e908949-128d-4a92-92fe-ae7a2b022e04\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6e908949-128d-4a92-92fe-ae7a2b022e04/pipeline.log\">pipeline</a>"]},{"id":"5c77f3a0-33db-4d4a-9702-4c0d08937dc1","name":"RHEL8 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1883.28255,"created":"2025-06-23T11:43:01.533183","updated":"2025-06-23T11:43:01.533190","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c77f3a0-33db-4d4a-9702-4c0d08937dc1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5c77f3a0-33db-4d4a-9702-4c0d08937dc1/pipeline.log\">pipeline</a>"]},{"id":"6be98e30-b50c-4b45-8029-81dc7ecf29e8","name":"RHEL9 - PyTest - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2015.997846,"created":"2025-06-23T11:43:00.985391","updated":"2025-06-23T11:43:00.985398","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be98e30-b50c-4b45-8029-81dc7ecf29e8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6be98e30-b50c-4b45-8029-81dc7ecf29e8/pipeline.log\">pipeline</a>"]},{"id":"bb6a4f98-9c30-4863-bc17-2bca5a90bf2f","name":"RHEL8 - PyTest - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1953.813399,"created":"2025-06-23T11:43:00.872029","updated":"2025-06-23T11:43:00.872034","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bb6a4f98-9c30-4863-bc17-2bca5a90bf2f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bb6a4f98-9c30-4863-bc17-2bca5a90bf2f/pipeline.log\">pipeline</a>"]},{"id":"d58eaa33-e4f4-4867-b038-f1c265e99032","name":"RHEL9 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":2016.57193,"created":"2025-06-23T11:43:03.295418","updated":"2025-06-23T11:43:03.295424","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d58eaa33-e4f4-4867-b038-f1c265e99032\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d58eaa33-e4f4-4867-b038-f1c265e99032/pipeline.log\">pipeline</a>"]},{"id":"2cf3af87-8231-4487-a4b6-db2c453691ea","name":"RHEL9 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":2061.13422,"created":"2025-06-23T11:43:01.598387","updated":"2025-06-23T11:43:01.598394","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cf3af87-8231-4487-a4b6-db2c453691ea\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2cf3af87-8231-4487-a4b6-db2c453691ea/pipeline.log\">pipeline</a>"]},{"id":"06a39206-5660-4213-9e0b-0d57e2b92c7b","name":"RHEL9 - PyTest - OpenShift 4 - 3.12","runTime":2064.127203,"created":"2025-06-23T11:43:02.504547","updated":"2025-06-23T11:43:02.504556","compose":"RHEL-9.4.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/06a39206-5660-4213-9e0b-0d57e2b92c7b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/06a39206-5660-4213-9e0b-0d57e2b92c7b/pipeline.log\">pipeline</a>"]}]} -->