### PR TITLE
Do not test VERSIONS 3.9-minimal and 3.11-minimal in OpenShift 4

### DIFF
--- a/test/run-openshift-remote-cluster
+++ b/test/run-openshift-remote-cluster
@@ -41,9 +41,12 @@ export CT_OCP4_TEST=true
 test -n "${IMAGE_NAME-}" || false 'make sure $IMAGE_NAME is defined'
 test -n "${VERSION-}" || false 'make sure $VERSION is defined'
 
-
-TEST_SUMMARY=''
-TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "openshift-remote-cluster"
+if [[ "${VERSION}" == "3.9-minimal" ]] || [[ "${VERSION}" == "3.11-minimal" ]]; then
+  echo "Skipping tests for minimal images. We do not provide them in container catalog registry."
+  exit 0
+else
+  TEST_SUMMARY=''
+  TEST_SET=${TESTS:-$TEST_LIST} ct_run_tests_from_testset "openshift-remote-cluster"
+fi
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:
-

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -37,6 +37,10 @@ function ct_pull_or_import_postgresql() {
 
 # Check the imagestream
 function test_python_imagestream() {
+  if [[ "${VERSIONS}" == "3.12" ]] && [[ "${OS}" == "rhel8" ]]; then
+    echo "Skipping tests for ${VERSIONS}. It is not supported in Container Catalog. Imagestreams do not exist for them."
+    return 0
+  fi
   if [[ "${VERSIONS}" == "3.9-minimal" ]] || [[ "${VERSIONS}" == "3.11-minimal" ]]; then
     echo "Skipping tests for ${VERSIONS}. It is not supported in Container Catalog. Imagestreams do not exist for them."
     return 0
@@ -83,7 +87,7 @@ function test_python_s2i_app_ex() {
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
   fi
-  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]]; then
+  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]] || [[ "${VERSION}" == "3.12-minimal" ]]; then
     branch="4.2.x"
   else
     branch="2.2.x"
@@ -106,7 +110,7 @@ django-postgresql-persistent.json"
   if [[ "${VERSION}" == *"minimal"* ]]; then
     VERSION=$(echo "${VERSION}" | cut -d "-" -f 1)
   fi
-  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]]; then
+  if [[ "${VERSION}" == "3.11" ]] || [[ "${VERSION}" == "3.12" ]] || [[ "${VERSION}" == "3.12-minimal" ]]; then
     postgresql_image="quay.io/sclorg/postgresql-12-c8s|postgresql:12"
     postgresql_version="12"
     branch="4.2.x"


### PR DESCRIPTION
Do not test VERSIONS 3.9-minimal and 3.11-minimal in OpenShift 4

They are not present in RedHat Container Catalog.

<!-- testing-farm = {"lock":"false","comment-id":"3102831333","data":[{"id":"67213ed2-263a-4533-a00f-c0e97b049d02","name":"RHEL10 - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1986.812247,"created":"2025-07-22T14:18:54.800182","updated":"2025-07-22T14:18:54.800191","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/67213ed2-263a-4533-a00f-c0e97b049d02\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/67213ed2-263a-4533-a00f-c0e97b049d02/pipeline.log\">pipeline</a>"]},{"id":"c9585253-f7a0-45bf-bb77-ffc793531078","name":"RHEL9 - OpenShift 4 - 3.12-minimal","runTime":2236.9167,"created":"2025-07-22T14:18:53.759934","updated":"2025-07-22T14:18:53.759940","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9585253-f7a0-45bf-bb77-ffc793531078\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9585253-f7a0-45bf-bb77-ffc793531078/pipeline.log\">pipeline</a>"]},{"id":"d22b7149-338d-422f-805c-eec280ae41b5","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1278.127442,"created":"2025-07-22T13:44:56.926441","updated":"2025-07-22T13:44:56.926447","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d22b7149-338d-422f-805c-eec280ae41b5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d22b7149-338d-422f-805c-eec280ae41b5/pipeline.log\">pipeline</a>"]},{"id":"9cd4f7e1-67b5-4489-a4bd-2deafa5c7885","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1542.484998,"created":"2025-07-22T13:44:54.363961","updated":"2025-07-22T13:44:54.363968","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cd4f7e1-67b5-4489-a4bd-2deafa5c7885\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9cd4f7e1-67b5-4489-a4bd-2deafa5c7885/pipeline.log\">pipeline</a>"]},{"id":"c2695372-65bf-4aa2-86b2-2c24d5b4c706","name":"RHEL8 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1526.390645,"created":"2025-07-22T13:44:54.251383","updated":"2025-07-22T13:44:54.251388","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2695372-65bf-4aa2-86b2-2c24d5b4c706\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c2695372-65bf-4aa2-86b2-2c24d5b4c706/pipeline.log\">pipeline</a>"]},{"id":"40cebe1c-5d1c-4167-b1c1-85cabdd0078e","name":"RHEL9 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":1651.498193,"created":"2025-07-22T13:44:54.377850","updated":"2025-07-22T13:44:54.377857","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/40cebe1c-5d1c-4167-b1c1-85cabdd0078e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/40cebe1c-5d1c-4167-b1c1-85cabdd0078e/pipeline.log\">pipeline</a>"]},{"id":"8e71df87-6840-410c-a13e-e4631f64fcf5","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":1791.613739,"created":"2025-07-22T13:44:54.199797","updated":"2025-07-22T13:44:54.199803","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e71df87-6840-410c-a13e-e4631f64fcf5\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e71df87-6840-410c-a13e-e4631f64fcf5/pipeline.log\">pipeline</a>"]},{"id":"1dd4aada-9311-4819-95a2-daac6fe4d87c","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":1731.531324,"created":"2025-07-22T13:44:57.793734","updated":"2025-07-22T13:44:57.793741","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1dd4aada-9311-4819-95a2-daac6fe4d87c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1dd4aada-9311-4819-95a2-daac6fe4d87c/pipeline.log\">pipeline</a>"]}]} -->