### PR TITLE
Drop scl_enable, switch defaults to ubi9/rhel9, improve docs

### DIFF
--- a/3.11-minimal/Dockerfile.c9s
+++ b/3.11-minimal/Dockerfile.c9s
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.11 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.11-minimal/Dockerfile.rhel8
+++ b/3.11-minimal/Dockerfile.rhel8
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.11 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.11-minimal/root/opt/app-root/etc/scl_enable
+++ b/3.11-minimal/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.11-minimal/s2i/bin/run
+++ b/3.11-minimal/s2i/bin/run
@@ -133,8 +133,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.11-minimal/test/run
+++ b/3.11-minimal/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile_minimal
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -238,21 +237,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.11/Dockerfile.c9s
+++ b/3.11/Dockerfile.c9s
@@ -77,13 +77,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.11/Dockerfile.rhel8
+++ b/3.11/Dockerfile.rhel8
@@ -83,13 +83,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.11/Dockerfile.rhel9
+++ b/3.11/Dockerfile.rhel9
@@ -82,13 +82,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.11/README.md
+++ b/3.11/README.md
@@ -2,10 +2,10 @@ Python 3.11 container image
 =========================
 
 This container image includes Python 3.11 as a [S2I](https://github.com/openshift/source-to-image) base image for your Python 3.11 applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.11-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.11-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.11-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:3.11-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/3.11/root/opt/app-root/etc/scl_enable
+++ b/3.11/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.11/s2i/bin/run
+++ b/3.11/s2i/bin/run
@@ -131,8 +131,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.11/test/run
+++ b/3.11/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -242,21 +241,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.12-minimal/Dockerfile.c10s
+++ b/3.12-minimal/Dockerfile.c10s
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.12 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.12-minimal/Dockerfile.c9s
+++ b/3.12-minimal/Dockerfile.c9s
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.12 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.12-minimal/Dockerfile.fedora
+++ b/3.12-minimal/Dockerfile.fedora
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.12 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.12-minimal/Dockerfile.rhel10
+++ b/3.12-minimal/Dockerfile.rhel10
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.12 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.12-minimal/Dockerfile.rhel9
+++ b/3.12-minimal/Dockerfile.rhel9
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.12 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.12-minimal/root/opt/app-root/etc/scl_enable
+++ b/3.12-minimal/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.12-minimal/s2i/bin/run
+++ b/3.12-minimal/s2i/bin/run
@@ -133,8 +133,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.12-minimal/test/run
+++ b/3.12-minimal/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile_minimal
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -238,21 +237,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.12/Dockerfile.c10s
+++ b/3.12/Dockerfile.c10s
@@ -76,13 +76,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.12/Dockerfile.c9s
+++ b/3.12/Dockerfile.c9s
@@ -77,13 +77,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.12/Dockerfile.fedora
+++ b/3.12/Dockerfile.fedora
@@ -76,13 +76,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.12/Dockerfile.rhel8
+++ b/3.12/Dockerfile.rhel8
@@ -83,13 +83,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.12/Dockerfile.rhel9
+++ b/3.12/Dockerfile.rhel9
@@ -82,13 +82,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.12/README.md
+++ b/3.12/README.md
@@ -2,10 +2,10 @@ Python 3.12 container image
 =========================
 
 This container image includes Python 3.12 as a [S2I](https://github.com/openshift/source-to-image) base image for your Python 3.12 applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.12-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.12-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.12-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:3.12-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/3.12/root/opt/app-root/etc/scl_enable
+++ b/3.12/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.12/s2i/bin/run
+++ b/3.12/s2i/bin/run
@@ -131,8 +131,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.12/test/run
+++ b/3.12/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -242,21 +241,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.13/Dockerfile.fedora
+++ b/3.13/Dockerfile.fedora
@@ -76,13 +76,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.13/README.md
+++ b/3.13/README.md
@@ -2,10 +2,10 @@ Python 3.13 container image
 =========================
 
 This container image includes Python 3.13 as a [S2I](https://github.com/openshift/source-to-image) base image for your Python 3.13 applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.13-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.13-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.13-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:3.13-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/3.13/root/opt/app-root/etc/scl_enable
+++ b/3.13/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.13/s2i/bin/run
+++ b/3.13/s2i/bin/run
@@ -131,8 +131,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.13/test/run
+++ b/3.13/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -242,21 +241,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.6/Dockerfile.rhel8
+++ b/3.6/Dockerfile.rhel8
@@ -68,13 +68,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -2,10 +2,10 @@ Python 3.6 container image
 =========================
 
 This container image includes Python 3.6 as a [S2I](https://github.com/openshift/source-to-image) base image for your Python 3.6 applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.6-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.6-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.6-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:3.6-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/3.6/root/opt/app-root/etc/scl_enable
+++ b/3.6/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.6/s2i/bin/run
+++ b/3.6/s2i/bin/run
@@ -131,8 +131,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.6/test/run
+++ b/3.6/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -241,21 +240,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.9-minimal/Dockerfile.c9s
+++ b/3.9-minimal/Dockerfile.c9s
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.9 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.9-minimal/Dockerfile.rhel8
+++ b/3.9-minimal/Dockerfile.rhel8
@@ -23,13 +23,10 @@ ENV PYTHON_VERSION=3.9 \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/3.9-minimal/root/opt/app-root/etc/scl_enable
+++ b/3.9-minimal/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.9-minimal/s2i/bin/run
+++ b/3.9-minimal/s2i/bin/run
@@ -133,8 +133,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.9-minimal/test/run
+++ b/3.9-minimal/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile_minimal
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -238,21 +237,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/3.9/Dockerfile.c9s
+++ b/3.9/Dockerfile.c9s
@@ -77,13 +77,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.9/Dockerfile.rhel8
+++ b/3.9/Dockerfile.rhel8
@@ -83,13 +83,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.9/Dockerfile.rhel9
+++ b/3.9/Dockerfile.rhel9
@@ -82,13 +82,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/3.9/README.md
+++ b/3.9/README.md
@@ -2,10 +2,10 @@ Python 3.9 container image
 =========================
 
 This container image includes Python 3.9 as a [S2I](https://github.com/openshift/source-to-image) base image for your Python 3.9 applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.9-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:3.9-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:3.9-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:3.9-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/3.9/root/opt/app-root/etc/scl_enable
+++ b/3.9/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL 
-fi
-source /opt/app-root/bin/activate

--- a/3.9/s2i/bin/run
+++ b/3.9/s2i/bin/run
@@ -131,8 +131,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/3.9/test/run
+++ b/3.9/test/run
@@ -38,7 +38,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile
 "
 
@@ -48,7 +47,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -128,7 +127,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -242,21 +241,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Images available on Quay are:
 This repository contains the source for building various versions of
 the Python application as a reproducible container image using
 [source-to-image](https://github.com/openshift/source-to-image).
-Users can choose between RHEL, Fedora and CentOS based builder images.
+Users can choose between RHEL, Fedora and CentOS Stream based builder images.
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -165,4 +165,3 @@ Repository organization
         * **run**
 
             Script that runs the [S2I](https://github.com/openshift/source-to-image) test framework.
-

--- a/examples/numpy-test-app/requirements.txt
+++ b/examples/numpy-test-app/requirements.txt
@@ -1,6 +1,5 @@
 gunicorn>=20.0.0; python_version >= '3.5'
-# Numpy 1.23.0 no longer builds from source
-# on RHEL 7 with old GCC
+# Numpy 1.23.0 no longer builds from source on very old GCC toolchains
 numpy<1.23.0; python_version >= '3.6' and python_version < '3.11'
 
 # numpy 1.23.5 is the first one with wheels for Python 3.11

--- a/manifest-minimal.yml
+++ b/manifest-minimal.yml
@@ -3,8 +3,6 @@ DISTGEN_RULES:
   - src: src/README-minimal.md
     dest: README.md
 
-  - src: src/root/opt/app-root/etc/scl_enable
-    dest: root/opt/app-root/etc/scl_enable
 
   - src: src/s2i/bin/assemble
     dest: s2i/bin/assemble

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,8 +3,6 @@ DISTGEN_RULES:
   - src: src/README.md
     dest: README.md
 
-  - src: src/root/opt/app-root/etc/scl_enable
-    dest: root/opt/app-root/etc/scl_enable
 
   - src: src/s2i/bin/assemble
     dest: s2i/bin/assemble

--- a/src/Dockerfile-minimal.template
+++ b/src/Dockerfile-minimal.template
@@ -25,13 +25,10 @@ ENV PYTHON_VERSION={{ spec.version }} \
 # /opt/app-root/src/.local/bin - tools like pipenv
 ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
 
-# RHEL7 base images automatically set these envvars to run scl_enable. RHEl8
-# images, however, don't as most images don't need SCLs any more. But we want
-# to run it even on RHEL8, because we set the virtualenv environment as part of
-# that script
-ENV BASH_ENV=${APP_ROOT}/etc/scl_enable \
-    ENV=${APP_ROOT}/etc/scl_enable \
-    PROMPT_COMMAND=". ${APP_ROOT}/etc/scl_enable"
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
 
 ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
     DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \

--- a/src/README.md
+++ b/src/README.md
@@ -2,10 +2,10 @@ Python {{ spec.version }} container image
 =========================
 
 This container image includes Python {{ spec.version }} as a [S2I](https://github.com/openshift/source-to-image) base image for your Python {{ spec.version }} applications.
-Users can choose between RHEL and CentOS based builder images.
+Users can choose between RHEL, CentOS Stream, and Fedora based builder images.
 The RHEL images are available in the [Red Hat Container Catalog](https://catalog.redhat.com/software/containers/explore),
-the CentOS images are available on [Quay.io](https://quay.io/organization/centos7),
-and the Fedora images are available in [Quay.io](https://quay.io/organization/fedora).
+CentOS Stream images are available on [Quay.io](https://quay.io/organization/sclorg),
+and the Fedora images are available on [Quay.io](https://quay.io/organization/fedora).
 The resulting image can be run using [podman](https://github.com/containers/libpod) or
 [docker](http://docker.io).
 
@@ -32,12 +32,12 @@ the nodejs itself is included just to make the npm work.
 Usage in Openshift
 ------------------
 
-For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:{{ spec.version }}-ubi8`
+For this, we will assume that you are using one of the supported images available via imagestream tags in Openshift, eg. `python:{{ spec.version }}-ubi9`
 Building a simple [python-sample-app](https://github.com/sclorg/django-ex.git) application
 in Openshift can be achieved with the following step:
 
     ```
-    oc new-app python:{{ spec.version }}-ubi8~https://github.com/sclorg/django-ex.git
+    oc new-app python:{{ spec.version }}-ubi9~https://github.com/sclorg/django-ex.git
     ```
 
 **Accessing the application:**

--- a/src/centos-stream/macros.tpl
+++ b/src/centos-stream/macros.tpl
@@ -35,13 +35,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/src/fedora/macros.tpl
+++ b/src/fedora/macros.tpl
@@ -31,13 +31,10 @@ rm -r /opt/wheels && \
 chown -R 1001:0 ${APP_ROOT} && \
 fix-permissions ${APP_ROOT} -P && \
 # The following echo adds the unset command for the variables set below to the \
-# venv activation script. This is inspired from scl_enable script and prevents \
-# the virtual environment to be activated multiple times and also every time \
-# the prompt is rendered. \
+# venv activation script. This prevents the virtual environment from being \
+# activated multiple times and also every time the prompt is rendered. \
 echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For Fedora scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/src/rhel/macros.tpl
+++ b/src/rhel/macros.tpl
@@ -48,13 +48,10 @@ RUN \
     fix-permissions ${APP_ROOT} -P && \
     rpm-file-permissions && \
     # The following echo adds the unset command for the variables set below to the \
-    # venv activation script. This is inspired from scl_enable script and prevents \
-    # the virtual environment to be activated multiple times and also every time \
-    # the prompt is rendered. \
+    # venv activation script. This prevents the virtual environment from being \
+    # activated multiple times and also every time the prompt is rendered. \
     echo "unset BASH_ENV PROMPT_COMMAND ENV" >> ${APP_ROOT}/bin/activate
-
-# For RHEL/Centos 8+ scl_enable isn't sourced automatically in s2i-core
-# so virtualenv needs to be activated this way
+# Ensure the virtualenv is activated in interactive shells
 ENV BASH_ENV="${APP_ROOT}/bin/activate" \
     ENV="${APP_ROOT}/bin/activate" \
     PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"

--- a/src/root/opt/app-root/etc/scl_enable
+++ b/src/root/opt/app-root/etc/scl_enable
@@ -1,9 +1,0 @@
-# IMPORTANT: Do not add more content to this file unless you know what you are
-#            doing. This file is sourced everytime the shell session is opened.
-# This will make scl collection binaries work out of box.
-unset BASH_ENV PROMPT_COMMAND ENV
-if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
-   head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7"; then
-    source scl_source enable httpd24 $NODEJS_SCL {{ spec.scl }}
-fi
-source /opt/app-root/bin/activate

--- a/src/s2i/bin/run
+++ b/src/s2i/bin/run
@@ -137,8 +137,8 @@ if is_gunicorn_installed; then
       gunicorn_settings_source="custom"
     fi
 
-    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable but because this is not
-    # supported in Gunicorn < 20 we still need for Python 2, we are using arguments directly.
+    # Gunicorn can read GUNICORN_CMD_ARGS as an env variable; we also pass them as
+    # arguments explicitly for compatibility with older Gunicorn versions.
     echo "---> Serving application with gunicorn ($APP_MODULE) with $gunicorn_settings_source settings ..."
     exec gunicorn "$APP_MODULE" $GUNICORN_CMD_ARGS --config "$APP_CONFIG"
   fi

--- a/test/run
+++ b/test/run
@@ -42,7 +42,6 @@ test_application_enable_init_wrapper
 "
 
 TEST_VAR_DOCKER="\
-test_scl_variables_in_dockerfile
 test_from_dockerfile{% if spec.minimal %}_minimal{% endif %}
 
 "
@@ -53,7 +52,7 @@ if [[ -z $VERSION ]]; then
     exit 1
 fi
 
-IMAGE_NAME=${IMAGE_NAME:-centos/python-${VERSION//./}-centos7}
+IMAGE_NAME=${IMAGE_NAME:-ubi9/python-${VERSION//./}}
 
 . test/test-lib.sh
 
@@ -134,7 +133,7 @@ test_scl_usage() {
   local expected="$2"
   local cid_file="$3"
 
-  info "Testing the image SCL enable"
+  info "Testing command availability in the image"
   out=$(docker run --rm ${IMAGE_NAME} /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -254,21 +253,6 @@ test_application_with_user() {
 test_application_enable_init_wrapper() {
   # test application with init wrapper
   CONTAINER_ARGS="-e ENABLE_INIT_WRAPPER=true" test_application
-}
-
-test_scl_variables_in_dockerfile() {
-  if [ "$OS" == "rhel7" ] || [ "$OS" == "centos7" ]; then
-     TESTCASE_RESULT=0
-     CID_FILE_DIR=$(mktemp -d)
-
-     info "Testing variable presence during \`docker exec\`"
-     ct_check_exec_env_vars
-     ct_check_testcase_result $?
-
-     info "Checking if all scl variables are defined in Dockerfile"
-     ct_check_scl_enable_vars
-     ct_check_testcase_result $?
-  fi
 }
 
 # Positive test & non-zero exit status = ERROR.

--- a/test/run-openshift-pytest
+++ b/test/run-openshift-pytest
@@ -3,7 +3,7 @@
 # IMAGE_NAME specifies a name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 # VERSION specifies the major version of the MariaDB in format of X.Y
-# OS specifies RHEL version (e.g. OS=rhel7)
+# OS specifies RHEL version (e.g. OS=rhel9)
 #
 
 THISDIR=$(dirname ${BASH_SOURCE[0]})

--- a/test/test-lib-python.sh
+++ b/test/test-lib-python.sh
@@ -45,9 +45,9 @@ function test_python_imagestream() {
     echo "Skipping tests for ${VERSIONS}. It is not supported in Container Catalog. Imagestreams do not exist for them."
     return 0
   fi
-  local tag="-ubi8"
-  if [ "${OS}" == "rhel9" ]; then
-    tag="-ubi9"
+  local tag="-ubi9"
+  if [ "${OS}" == "rhel8" ]; then
+    tag="-ubi8"
   elif [ "${OS}" == "rhel10" ]; then
     tag="-ubi10"
   fi
@@ -140,4 +140,3 @@ function test_latest_imagestreams() {
 
 
 # vim: set tabstop=2:shiftwidth=2:expandtab:
-


### PR DESCRIPTION
Refresh and various improvements across the repo.

<!-- testing-farm = {"lock":"false","comment-id":"3245154086","data":[{"id":"16c4b12d-76ae-4e04-ab42-cc41a0c7df4b","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1315.778276,"created":"2025-09-02T12:17:11.769325","updated":"2025-09-02T12:17:11.769330","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/16c4b12d-76ae-4e04-ab42-cc41a0c7df4b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/16c4b12d-76ae-4e04-ab42-cc41a0c7df4b/pipeline.log\">pipeline</a>"]},{"id":"bbd94f63-58ed-4e39-b03f-d6c5f9b46d65","name":"Fedora - 3.12-minimal","status":"complete","outcome":"passed","runTime":1687.969735,"created":"2025-09-02T12:10:39.703664","updated":"2025-09-02T12:10:39.703670","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bbd94f63-58ed-4e39-b03f-d6c5f9b46d65\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bbd94f63-58ed-4e39-b03f-d6c5f9b46d65/pipeline.log\">pipeline</a>"]},{"id":"4c3a6b32-fc73-4314-b8b4-bc1ee72a11ee","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":2057.583088,"created":"2025-09-02T12:05:09.145262","updated":"2025-09-02T12:05:09.145270","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4c3a6b32-fc73-4314-b8b4-bc1ee72a11ee\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4c3a6b32-fc73-4314-b8b4-bc1ee72a11ee/pipeline.log\">pipeline</a>"]},{"id":"ca15526b-cc8e-4d0f-bb9b-6b459f4e1d64","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":831.273804,"created":"2025-09-02T12:39:04.282567","updated":"2025-09-02T12:39:04.282580","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ca15526b-cc8e-4d0f-bb9b-6b459f4e1d64\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ca15526b-cc8e-4d0f-bb9b-6b459f4e1d64/pipeline.log\">pipeline</a>"]},{"id":"8755db91-05de-4ca0-a76f-25d504a1c9aa","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1097.135769,"created":"2025-09-02T12:39:41.944177","updated":"2025-09-02T12:39:41.944184","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/8755db91-05de-4ca0-a76f-25d504a1c9aa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/8755db91-05de-4ca0-a76f-25d504a1c9aa/pipeline.log\">pipeline</a>"]},{"id":"a1f7a4cd-d414-4b52-b1fe-e0a976f64306","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":916.090175,"created":"2025-09-02T12:52:48.988107","updated":"2025-09-02T12:52:48.988139","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a1f7a4cd-d414-4b52-b1fe-e0a976f64306\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a1f7a4cd-d414-4b52-b1fe-e0a976f64306/pipeline.log\">pipeline</a>"]},{"id":"f2ef49f0-6d57-4f18-89fd-b67bd9fc82d3","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":960.483856,"created":"2025-09-02T12:53:24.834598","updated":"2025-09-02T12:53:24.834603","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f2ef49f0-6d57-4f18-89fd-b67bd9fc82d3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f2ef49f0-6d57-4f18-89fd-b67bd9fc82d3/pipeline.log\">pipeline</a>"]},{"id":"0c6130ea-f12f-44fe-a999-ad6678877059","name":"RHEL9 - PyTest - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":3902.531,"created":"2025-09-02T12:13:36.020973","updated":"2025-09-02T12:13:36.020982","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c6130ea-f12f-44fe-a999-ad6678877059\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0c6130ea-f12f-44fe-a999-ad6678877059/pipeline.log\">pipeline</a>"]},{"id":"611f31e3-15c2-43c1-b63d-f58917dc8cbc","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1116.53999,"created":"2025-09-02T13:10:10.376621","updated":"2025-09-02T13:10:10.376627","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/611f31e3-15c2-43c1-b63d-f58917dc8cbc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/611f31e3-15c2-43c1-b63d-f58917dc8cbc/pipeline.log\">pipeline</a>"]},{"id":"8344493b-33c6-4b11-8149-ef9cc566def0","name":"RHEL8 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":4337.577213,"created":"2025-09-02T12:33:09.044873","updated":"2025-09-02T12:33:09.044882","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8344493b-33c6-4b11-8149-ef9cc566def0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8344493b-33c6-4b11-8149-ef9cc566def0/pipeline.log\">pipeline</a>"]},{"id":"f0e03962-cdfb-4778-aa0d-d899181e48c7","name":"RHEL8 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":4750.488653,"created":"2025-09-02T12:32:07.638804","updated":"2025-09-02T12:32:07.638815","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0e03962-cdfb-4778-aa0d-d899181e48c7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f0e03962-cdfb-4778-aa0d-d899181e48c7/pipeline.log\">pipeline</a>"]},{"id":"80ed58a2-e4e7-4159-b492-d8da09defcba","name":"RHEL8 - PyTest - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":4844.463655,"created":"2025-09-02T12:34:15.996421","updated":"2025-09-02T12:34:15.996429","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/80ed58a2-e4e7-4159-b492-d8da09defcba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/80ed58a2-e4e7-4159-b492-d8da09defcba/pipeline.log\">pipeline</a>"]},{"id":"6550b0fd-9e71-4079-b773-e72238399ec2","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":4820.445162,"created":"2025-09-02T12:39:58.351684","updated":"2025-09-02T12:39:58.351691","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6550b0fd-9e71-4079-b773-e72238399ec2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6550b0fd-9e71-4079-b773-e72238399ec2/pipeline.log\">pipeline</a>"]},{"id":"53f2ee92-1f8a-48f2-b101-f7002104d7fd","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":5069.344027,"created":"2025-09-02T12:38:02.481007","updated":"2025-09-02T12:38:02.481015","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/53f2ee92-1f8a-48f2-b101-f7002104d7fd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/53f2ee92-1f8a-48f2-b101-f7002104d7fd/pipeline.log\">pipeline</a>"]},{"id":"13a4770a-227d-4667-8a80-fc4f24b85a89","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":4877.006246,"created":"2025-09-02T12:42:44.148762","updated":"2025-09-02T12:42:44.148770","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/13a4770a-227d-4667-8a80-fc4f24b85a89\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/13a4770a-227d-4667-8a80-fc4f24b85a89/pipeline.log\">pipeline</a>"]},{"id":"c9e6e9b5-0416-44e5-9185-c634ea3118c4","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":4906.115329,"created":"2025-09-02T12:43:43.898249","updated":"2025-09-02T12:43:43.898258","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9e6e9b5-0416-44e5-9185-c634ea3118c4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c9e6e9b5-0416-44e5-9185-c634ea3118c4/pipeline.log\">pipeline</a>"]},{"id":"7276e6c3-0846-48f7-b805-a3cc3a811ab0","name":"RHEL8 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":5318.30204,"created":"2025-09-02T12:36:07.883932","updated":"2025-09-02T12:36:07.883939","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7276e6c3-0846-48f7-b805-a3cc3a811ab0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7276e6c3-0846-48f7-b805-a3cc3a811ab0/pipeline.log\">pipeline</a>"]},{"id":"0267ed03-247b-4649-8f7a-3db8426c689c","name":"RHEL9 - OpenShift 4 - 3.12","status":"complete","outcome":"passed","runTime":4976.737099,"created":"2025-09-02T12:47:23.685376","updated":"2025-09-02T12:47:23.685382","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0267ed03-247b-4649-8f7a-3db8426c689c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0267ed03-247b-4649-8f7a-3db8426c689c/pipeline.log\">pipeline</a>"]},{"id":"795c958e-f044-49fa-8953-d960120e6f53","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":5078.184412,"created":"2025-09-02T12:46:24.911359","updated":"2025-09-02T12:46:24.911366","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/795c958e-f044-49fa-8953-d960120e6f53\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/795c958e-f044-49fa-8953-d960120e6f53/pipeline.log\">pipeline</a>"]},{"id":"717bd694-ac99-4eb2-aec5-5d1927be3393","name":"RHEL9 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":5231.787496,"created":"2025-09-02T12:46:43.302063","updated":"2025-09-02T12:46:43.302069","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/717bd694-ac99-4eb2-aec5-5d1927be3393\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/717bd694-ac99-4eb2-aec5-5d1927be3393/pipeline.log\">pipeline</a>"]},{"id":"1c4d7ef2-a926-443d-8584-6e9ae9dea4bc","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":969.070716,"created":"2025-09-02T14:02:24.500370","updated":"2025-09-02T14:02:24.500377","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1c4d7ef2-a926-443d-8584-6e9ae9dea4bc\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1c4d7ef2-a926-443d-8584-6e9ae9dea4bc/pipeline.log\">pipeline</a>"]},{"id":"1f7d53e9-d23b-42a0-b85c-dfe3ed841a9c","name":"RHEL9 - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":5501.479395,"created":"2025-09-02T12:48:45.731694","updated":"2025-09-02T12:48:45.731705","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f7d53e9-d23b-42a0-b85c-dfe3ed841a9c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1f7d53e9-d23b-42a0-b85c-dfe3ed841a9c/pipeline.log\">pipeline</a>"]},{"id":"ae0ac935-29a2-463d-ba60-e018257f6e24","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":5217.425316,"created":"2025-09-02T12:53:26.096172","updated":"2025-09-02T12:53:26.096179","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae0ac935-29a2-463d-ba60-e018257f6e24\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ae0ac935-29a2-463d-ba60-e018257f6e24/pipeline.log\">pipeline</a>"]},{"id":"0ae8095f-14cd-40aa-bc25-a8ab24f9e5aa","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":5232.559908,"created":"2025-09-02T12:56:41.158973","updated":"2025-09-02T12:56:41.158980","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ae8095f-14cd-40aa-bc25-a8ab24f9e5aa\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ae8095f-14cd-40aa-bc25-a8ab24f9e5aa/pipeline.log\">pipeline</a>"]},{"id":"8ef651ac-bfc7-4ce7-b582-410ef200a7ef","name":"RHEL8 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":3106.895529,"created":"2025-09-02T13:43:54.118261","updated":"2025-09-02T13:43:54.118267","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ef651ac-bfc7-4ce7-b582-410ef200a7ef\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8ef651ac-bfc7-4ce7-b582-410ef200a7ef/pipeline.log\">pipeline</a>"]},{"id":"22095c9c-f14f-436e-bc54-4abf66da6ca1","name":"RHEL10 - PyTest - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2788.271728,"created":"2025-09-02T13:51:03.492588","updated":"2025-09-02T13:51:03.492598","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/22095c9c-f14f-436e-bc54-4abf66da6ca1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/22095c9c-f14f-436e-bc54-4abf66da6ca1/pipeline.log\">pipeline</a>"]},{"id":"46a24475-2b09-4551-8017-d8d7efe7b521","name":"RHEL9 - PyTest - OpenShift 4 - 3.11","status":"complete","outcome":"passed","runTime":4139.658321,"created":"2025-09-02T13:30:14.992644","updated":"2025-09-02T13:30:14.992652","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/46a24475-2b09-4551-8017-d8d7efe7b521\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/46a24475-2b09-4551-8017-d8d7efe7b521/pipeline.log\">pipeline</a>"]},{"id":"58c73ada-4140-4932-ba9d-64a6ecaa6f86","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":2449.357525,"created":"2025-09-02T14:06:30.646393","updated":"2025-09-02T14:06:30.646401","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/58c73ada-4140-4932-ba9d-64a6ecaa6f86\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/58c73ada-4140-4932-ba9d-64a6ecaa6f86/pipeline.log\">pipeline</a>"]},{"id":"d0b6a247-35bc-4a1f-b2b6-dfd331b9ad98","name":"RHEL9 - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2592.851221,"created":"2025-09-02T14:04:35.976252","updated":"2025-09-02T14:04:35.976259","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0b6a247-35bc-4a1f-b2b6-dfd331b9ad98\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d0b6a247-35bc-4a1f-b2b6-dfd331b9ad98/pipeline.log\">pipeline</a>"]},{"id":"ec30b74c-8940-4fb1-a56c-87f251affc0c","name":"Fedora - 3.12","status":"complete","outcome":"passed","runTime":1136.275498,"created":"2025-09-02T14:41:25.615285","updated":"2025-09-02T14:41:25.615291","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ec30b74c-8940-4fb1-a56c-87f251affc0c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ec30b74c-8940-4fb1-a56c-87f251affc0c/pipeline.log\">pipeline</a>"]},{"id":"a9b6d59f-9a8a-4b04-b489-dd7ab6d58fac","name":"RHEL10 - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2302.571554,"created":"2025-09-02T14:22:10.521155","updated":"2025-09-02T14:22:10.521161","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9b6d59f-9a8a-4b04-b489-dd7ab6d58fac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a9b6d59f-9a8a-4b04-b489-dd7ab6d58fac/pipeline.log\">pipeline</a>"]},{"id":"bd296a3a-2881-451f-9da9-17c88f04f66f","name":"RHEL9 - PyTest - OpenShift 4 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2629.410755,"created":"2025-09-02T14:24:55.444918","updated":"2025-09-02T14:24:55.444925","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd296a3a-2881-451f-9da9-17c88f04f66f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/bd296a3a-2881-451f-9da9-17c88f04f66f/pipeline.log\">pipeline</a>"]},{"id":"118bca84-c9e9-434f-98f5-d24cc1e4f7d3","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1131.49466,"created":"2025-09-02T14:49:04.863310","updated":"2025-09-02T14:49:04.863317","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/118bca84-c9e9-434f-98f5-d24cc1e4f7d3\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/118bca84-c9e9-434f-98f5-d24cc1e4f7d3/pipeline.log\">pipeline</a>"]},{"id":"9f95e412-ec83-4588-8e58-2b11f30c5058","name":"RHEL8 - PyTest - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":3251.962529,"created":"2025-09-02T14:13:55.986390","updated":"2025-09-02T14:13:55.986396","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f95e412-ec83-4588-8e58-2b11f30c5058\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f95e412-ec83-4588-8e58-2b11f30c5058/pipeline.log\">pipeline</a>"]},{"id":"4f0b8753-643a-47c7-8b59-df36d9743d35","name":"RHEL9 - OpenShift 4 - 3.9","status":"complete","outcome":"passed","runTime":2762.097886,"created":"2025-09-02T14:28:48.946771","updated":"2025-09-02T14:28:48.946776","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f0b8753-643a-47c7-8b59-df36d9743d35\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f0b8753-643a-47c7-8b59-df36d9743d35/pipeline.log\">pipeline</a>"]},{"id":"e4eb370b-31ce-47ff-a710-515f82fffb87","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":2437.293667,"created":"2025-09-02T14:40:48.522817","updated":"2025-09-02T14:40:48.522827","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4eb370b-31ce-47ff-a710-515f82fffb87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4eb370b-31ce-47ff-a710-515f82fffb87/pipeline.log\">pipeline</a>"]},{"id":"5294e158-000e-4b77-95ee-9b0501f28aaf","name":"RHEL9 - 3.9","runTime":2633.119242,"created":"2025-09-02T14:39:26.438597","updated":"2025-09-02T14:39:26.438606","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5294e158-000e-4b77-95ee-9b0501f28aaf\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5294e158-000e-4b77-95ee-9b0501f28aaf/pipeline.log\">pipeline</a>"]}]} -->