### PR TITLE
Add Python 3.12 minimal image based on RHEL 8

### DIFF
--- a/3.12-minimal/Dockerfile.rhel8
+++ b/3.12-minimal/Dockerfile.rhel8
@@ -1,0 +1,105 @@
+FROM ubi8/ubi-minimal:latest
+
+
+EXPOSE 8080
+
+ENV PYTHON_VERSION=3.12 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    CNB_STACK_ID=com.redhat.stacks.ubi8-python-312 \
+    CNB_USER_ID=1001 \
+    CNB_GROUP_ID=0 \
+    PIP_NO_CACHE_DIR=off \
+    # The following variables are usually available from parent s2i images \
+    STI_SCRIPTS_PATH=/usr/libexec/s2i \
+    APP_ROOT=/opt/app-root \
+    HOME=/opt/app-root/src \
+    PLATFORM="el8"
+
+# /opt/app-root/bin - the main venv
+# /opt/app-root/src/bin - app-specific binaries
+# /opt/app-root/src/.local/bin - tools like pipenv
+ENV PATH=$APP_ROOT/bin:$HOME/bin:$HOME/.local/bin:$PATH
+
+# Ensure the virtual environment is active in interactive shells
+ENV BASH_ENV=${APP_ROOT}/bin/activate \
+    ENV=${APP_ROOT}/bin/activate \
+    PROMPT_COMMAND=". ${APP_ROOT}/bin/activate"
+
+ENV SUMMARY="Minimal platform for building and running Python $PYTHON_VERSION applications" \
+    DESCRIPTION="Python $PYTHON_VERSION available as container is a base platform for \
+building and running various Python $PYTHON_VERSION applications and frameworks. \
+Python is an easy to learn, powerful programming language. It has efficient high-level \
+data structures and a simple but effective approach to object-oriented programming. \
+Python's elegant syntax and dynamic typing, together with its interpreted nature, \
+make it an ideal language for scripting and rapid application development in many areas \
+on most platforms."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION" \
+      io.k8s.display-name="Python 3.12" \
+      io.openshift.expose-services="8080:http" \
+      io.openshift.tags="builder,python,python312,python-312,rh-python312" \
+      com.redhat.component="python-312-container" \
+      name="ubi8/python-312-minimal" \
+      version="1" \
+      usage="s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.12-minimal/test/setup-test-app/ ubi8/python-312-minimal python-sample-app" \
+      com.redhat.license_terms="https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI" \
+      io.buildpacks.stack.id="com.redhat.stacks.ubi8-python-312-minimal" \
+      maintainer="SoftwareCollections.org <sclorg@redhat.com>"
+
+# Very minimal set of packages
+# Python is obvious in the Python container :)
+# glibc-langpack-en is needed to set locale to en_US and disable warning about it
+# findutils - find command is needed for fix-permissions script
+# nss_wrapper - used in generate_container_user script
+RUN INSTALL_PKGS="python3.12 glibc-langpack-en findutils nss_wrapper-libs" && \
+    microdnf -y --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \
+    microdnf -y clean all --enablerepo='*'
+
+# Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH.
+COPY 3.12-minimal/s2i/bin/ $STI_SCRIPTS_PATH
+
+# Copy extra files to the image.
+COPY 3.12-minimal/root/ /
+
+# Python 3.7+ only
+# Yes, the directory below is already copied by the previous command.
+# The problem here is that the wheels directory is copied as a symlink.
+# Only if you specify symlink directly as a source, COPY copies all the
+# files from the symlink destination.
+COPY 3.12-minimal/root/opt/wheels /opt/wheels
+
+# This command sets (and also creates if necessary)
+# the home directory - it has to be done here so the latter
+# fix-permissions fixes this directory as well.
+WORKDIR ${HOME}
+
+# - Create a Python virtual environment for use by any application to avoid
+#   potential conflicts with Python packages preinstalled in the main Python
+#   installation.
+# - In order to drop the root user, we have to make some directories world
+#   writable as OpenShift default security model is to run the container
+#   under random UID.
+RUN \
+    python3.12 -m venv ${APP_ROOT} && \
+    # We have to upgrade pip to a newer version because \
+    # pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 (and later) wheels \
+    #   support platforms like ppc64le, aarch64 or armv7 \
+    # We are newly using wheel from one of the latest stable Fedora releases (from RPM python-pip-wheel) \
+    # because it's tested better then whatever version from PyPI and contains useful patches. \
+    # We have to do it here so the permissions are correctly fixed and pip is able \
+    # to reinstall itself in the next build phases in the assemble script if user wants the latest version \
+    ${APP_ROOT}/bin/pip install /opt/wheels/pip-* && \
+    rm -r /opt/wheels && \
+    chown -R 1001:0 ${APP_ROOT} && \
+    fix-permissions ${APP_ROOT} -P && \
+    rpm-file-permissions
+
+USER 1001
+
+# Set the default CMD to print the usage of the language image.
+CMD $STI_SCRIPTS_PATH/usage

--- a/specs/multispec.yml
+++ b/specs/multispec.yml
@@ -248,6 +248,7 @@ matrix:
     - distros:
         - centos-stream-10-x86_64
         - centos-stream-9-x86_64
+        - rhel-8-x86_64
         - rhel-9-x86_64
         - rhel-10-x86_64
       version: "3.12-minimal"


### PR DESCRIPTION
We have a CI configuration for this combo, but the docker file is missing for some reason.

<!-- testing-farm = {"lock":"false","comment-id":"3327720348","data":[{"id":"282d12a3-b4e4-441f-a229-b745a3bc9c00","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1191.608328,"created":"2025-09-24T10:24:50.075247","updated":"2025-09-24T10:24:50.075255","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/282d12a3-b4e4-441f-a229-b745a3bc9c00\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/282d12a3-b4e4-441f-a229-b745a3bc9c00/pipeline.log\">pipeline</a>"]},{"id":"4eacf7b3-25ad-4277-8826-b1572eb87b82","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1187.650315,"created":"2025-09-24T10:24:55.114182","updated":"2025-09-24T10:24:55.114191","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4eacf7b3-25ad-4277-8826-b1572eb87b82\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4eacf7b3-25ad-4277-8826-b1572eb87b82/pipeline.log\">pipeline</a>"]},{"id":"14f29cb0-8c0c-4143-b6f5-681d49969a1a","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1202.748683,"created":"2025-09-24T10:24:51.090964","updated":"2025-09-24T10:24:51.090973","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/14f29cb0-8c0c-4143-b6f5-681d49969a1a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/14f29cb0-8c0c-4143-b6f5-681d49969a1a/pipeline.log\">pipeline</a>"]},{"id":"7994d12e-d01b-4ac6-888d-1c2a1cadeb36","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1199.420315,"created":"2025-09-24T10:24:59.056060","updated":"2025-09-24T10:24:59.056069","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/7994d12e-d01b-4ac6-888d-1c2a1cadeb36\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/7994d12e-d01b-4ac6-888d-1c2a1cadeb36/pipeline.log\">pipeline</a>"]},{"id":"3b819bd3-beec-4b10-a12a-38b47a95f4d2","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1103.884232,"created":"2025-09-24T10:25:07.626312","updated":"2025-09-24T10:25:07.626319","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3b819bd3-beec-4b10-a12a-38b47a95f4d2\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3b819bd3-beec-4b10-a12a-38b47a95f4d2/pipeline.log\">pipeline</a>"]},{"id":"e9699c2d-25af-4498-a06a-145d4eba1221","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1266.609226,"created":"2025-09-24T10:24:51.890615","updated":"2025-09-24T10:24:51.890622","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e9699c2d-25af-4498-a06a-145d4eba1221\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e9699c2d-25af-4498-a06a-145d4eba1221/pipeline.log\">pipeline</a>"]},{"id":"448d0ec8-58c3-4f7d-8fd3-ec8d978a8b35","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1265.266876,"created":"2025-09-24T10:24:50.807706","updated":"2025-09-24T10:24:50.807712","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/448d0ec8-58c3-4f7d-8fd3-ec8d978a8b35\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/448d0ec8-58c3-4f7d-8fd3-ec8d978a8b35/pipeline.log\">pipeline</a>"]},{"id":"b5ac8f1d-323b-43b3-856b-6df929e0dbc8","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"passed","runTime":1251.83257,"created":"2025-09-24T10:25:25.859426","updated":"2025-09-24T10:25:25.859435","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b5ac8f1d-323b-43b3-856b-6df929e0dbc8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b5ac8f1d-323b-43b3-856b-6df929e0dbc8/pipeline.log\">pipeline</a>"]},{"id":"6c2277d7-77b6-4fb6-af6f-e46e3ca05e11","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1262.840515,"created":"2025-09-24T10:25:23.861080","updated":"2025-09-24T10:25:23.861087","compose":"RHEL-10-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c2277d7-77b6-4fb6-af6f-e46e3ca05e11\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6c2277d7-77b6-4fb6-af6f-e46e3ca05e11/pipeline.log\">pipeline</a>"]},{"id":"dd820c55-920f-41ea-8636-e19a31771a69","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1342.435763,"created":"2025-09-24T10:24:49.677023","updated":"2025-09-24T10:24:49.677029","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/dd820c55-920f-41ea-8636-e19a31771a69\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/dd820c55-920f-41ea-8636-e19a31771a69/pipeline.log\">pipeline</a>"]},{"id":"6ad458a5-d70f-4c9a-86bc-2e7f7df6d8c1","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1478.384539,"created":"2025-09-24T10:24:50.313481","updated":"2025-09-24T10:24:50.313489","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ad458a5-d70f-4c9a-86bc-2e7f7df6d8c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6ad458a5-d70f-4c9a-86bc-2e7f7df6d8c1/pipeline.log\">pipeline</a>"]},{"id":"afacc8d3-66b1-4aef-bd31-57d56a5e76a6","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1457.518828,"created":"2025-09-24T10:24:56.431379","updated":"2025-09-24T10:24:56.431386","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/afacc8d3-66b1-4aef-bd31-57d56a5e76a6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/afacc8d3-66b1-4aef-bd31-57d56a5e76a6/pipeline.log\">pipeline</a>"]},{"id":"c5ca3824-958c-48fd-92dc-94b1c0e60416","name":"RHEL8 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1481.12404,"created":"2025-09-24T10:24:50.058474","updated":"2025-09-24T10:24:50.058482","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5ca3824-958c-48fd-92dc-94b1c0e60416\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c5ca3824-958c-48fd-92dc-94b1c0e60416/pipeline.log\">pipeline</a>"]},{"id":"d06ea920-f92c-415a-a906-2356ddff5272","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1694.743036,"created":"2025-09-24T10:24:53.889888","updated":"2025-09-24T10:24:53.889897","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d06ea920-f92c-415a-a906-2356ddff5272\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d06ea920-f92c-415a-a906-2356ddff5272/pipeline.log\">pipeline</a>"]},{"id":"32760710-b98d-4696-b3d9-bece9cf4579e","name":"RHEL8 - 3.9","status":"complete","outcome":"passed","runTime":1749.341113,"created":"2025-09-24T10:24:51.517587","updated":"2025-09-24T10:24:51.517594","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/32760710-b98d-4696-b3d9-bece9cf4579e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/32760710-b98d-4696-b3d9-bece9cf4579e/pipeline.log\">pipeline</a>"]},{"id":"ea7e2156-f7d6-4898-a19a-3d10eb2f9a8b","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":1688.794277,"created":"2025-09-24T10:25:07.073649","updated":"2025-09-24T10:25:07.073655","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea7e2156-f7d6-4898-a19a-3d10eb2f9a8b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ea7e2156-f7d6-4898-a19a-3d10eb2f9a8b/pipeline.log\">pipeline</a>"]},{"id":"577c8e23-8efd-4d0a-9c2e-bcf900710ddb","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1831.805413,"created":"2025-09-24T10:24:49.191665","updated":"2025-09-24T10:24:49.191671","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/577c8e23-8efd-4d0a-9c2e-bcf900710ddb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/577c8e23-8efd-4d0a-9c2e-bcf900710ddb/pipeline.log\">pipeline</a>"]},{"id":"a13970fa-e740-4805-945a-dd8ee8db03c8","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":1814.279505,"created":"2025-09-24T10:24:57.563683","updated":"2025-09-24T10:24:57.563690","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/a13970fa-e740-4805-945a-dd8ee8db03c8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/a13970fa-e740-4805-945a-dd8ee8db03c8/pipeline.log\">pipeline</a>"]},{"id":"79a0f201-2504-47a1-ba01-4ec5072d9238","name":"RHEL9 - 3.9","runTime":1874.290446,"created":"2025-09-24T10:24:59.571068","updated":"2025-09-24T10:24:59.571076","compose":"RHEL-9.6.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/79a0f201-2504-47a1-ba01-4ec5072d9238\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/79a0f201-2504-47a1-ba01-4ec5072d9238/pipeline.log\">pipeline</a>"]}]} -->