### PR TITLE
mod-wsgi-test-app compatible with mod_wsgi 6.0.0

### DIFF
--- a/examples/mod-wsgi-test-app/app.py
+++ b/examples/mod-wsgi-test-app/app.py
@@ -1,7 +1,10 @@
 import os
-import mod_wsgi.server
+try:
+    import mod_wsgi.express.cli as server_wrapper
+except ImportError:
+  import mod_wsgi.server as server_wrapper
 
-mod_wsgi.server.start(
+server_wrapper.start(
   '--log-to-terminal',
   '--port', '8080',
   '--trust-proxy-header', 'X-Forwarded-For',


### PR DESCRIPTION
Keep it working with older mod_wsgi

There is another mod_wsgi example `micropipenv-requirements-test-app` but that has mod_wsgi frozen to 5.0.1

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->

<!-- testing-farm = {"lock":"true","comment-id":"4600311483","data":[{"id":"9f065157-61c9-4709-9570-13443d811baa","name":"Fedora - PyTest - 3.13-minimal","status":"complete","outcome":"passed","runTime":526.605871,"created":"2026-06-03T11:41:28.846807","updated":"2026-06-03T11:41:28.846816","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9f065157-61c9-4709-9570-13443d811baa\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9f065157-61c9-4709-9570-13443d811baa/pipeline.log\">pipeline</a>"]},{"id":"b2c6b9c9-4aae-4959-bc31-2fd4606b82ab","name":"CentOS Stream 9 - PyTest - 3.9-minimal","status":"complete","outcome":"passed","runTime":923.810523,"created":"2026-06-03T11:49:26.558726","updated":"2026-06-03T11:49:26.558735","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b2c6b9c9-4aae-4959-bc31-2fd4606b82ab\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b2c6b9c9-4aae-4959-bc31-2fd4606b82ab/pipeline.log\">pipeline</a>"]},{"id":"af644227-64bc-44f8-9900-8d54b925f644","name":"Fedora - PyTest - 3.13","status":"complete","outcome":"passed","runTime":958.804358,"created":"2026-06-02T08:19:38.766431","updated":"2026-06-02T08:19:38.766439","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/af644227-64bc-44f8-9900-8d54b925f644\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/af644227-64bc-44f8-9900-8d54b925f644/pipeline.log\">pipeline</a>"]},{"id":"ed47a2d7-b2cf-42f6-a22d-1f294628ffdd","name":"CentOS Stream 10 - PyTest - 3.13","runTime":1063.591845,"created":"2026-06-03T12:29:05.421656","updated":"2026-06-03T12:29:05.421663","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.dev.testing-farm.io/ed47a2d7-b2cf-42f6-a22d-1f294628ffdd\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ed47a2d7-b2cf-42f6-a22d-1f294628ffdd/pipeline.log\">pipeline</a>"]},{"id":"4dce6a20-3ecf-454c-9cb0-0dd8c8ea3c67","name":"CentOS Stream 10 - PyTest - 3.12","status":"complete","outcome":"passed","runTime":1090.574006,"created":"2026-06-02T08:19:39.673016","updated":"2026-06-02T08:19:39.673025","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4dce6a20-3ecf-454c-9cb0-0dd8c8ea3c67\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4dce6a20-3ecf-454c-9cb0-0dd8c8ea3c67/pipeline.log\">pipeline</a>"]},{"id":"d2fb1de5-1670-48b2-a0cc-ac801cec2b67","name":"CentOS Stream 9 - 3.14","status":"complete","outcome":"passed","runTime":1297.796086,"created":"2026-06-02T08:19:38.258925","updated":"2026-06-02T08:19:38.258932","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d2fb1de5-1670-48b2-a0cc-ac801cec2b67\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d2fb1de5-1670-48b2-a0cc-ac801cec2b67/pipeline.log\">pipeline</a>"]},{"id":"a03cd659-9c9c-4e00-84aa-da9e3958dd07","name":"Fedora - 3.14","status":"complete","outcome":"passed","runTime":1117.964633,"created":"2026-06-03T12:08:40.210047","updated":"2026-06-03T12:08:40.210055","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a03cd659-9c9c-4e00-84aa-da9e3958dd07\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a03cd659-9c9c-4e00-84aa-da9e3958dd07/pipeline.log\">pipeline</a>"]},{"id":"61d3cfa0-4eca-44b7-ab29-98cffd70c59b","name":"CentOS Stream 9 - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":859.265928,"created":"2026-06-03T12:21:40.182464","updated":"2026-06-03T12:21:40.182471","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/61d3cfa0-4eca-44b7-ab29-98cffd70c59b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/61d3cfa0-4eca-44b7-ab29-98cffd70c59b/pipeline.log\">pipeline</a>"]},{"id":"18347001-deb7-45dd-8f15-83d9b3803611","name":"CentOS Stream 9 - 3.11-minimal","status":"complete","outcome":"passed","runTime":1208.924567,"created":"2026-06-02T08:38:08.105873","updated":"2026-06-02T08:38:08.105880","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/18347001-deb7-45dd-8f15-83d9b3803611\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/18347001-deb7-45dd-8f15-83d9b3803611/pipeline.log\">pipeline</a>"]},{"id":"553a07e1-15cf-413a-960f-22b9f4749936","name":"RHEL8 - PyTest - 3.11","status":"complete","outcome":"passed","runTime":3040.468688,"created":"2026-06-02T08:19:40.294106","updated":"2026-06-02T08:19:40.294141","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/553a07e1-15cf-413a-960f-22b9f4749936\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/553a07e1-15cf-413a-960f-22b9f4749936/pipeline.log\">pipeline</a>"]},{"id":"773d0466-8451-4410-be2e-6a1353731082","name":"RHEL10 - Unsubscribed host - 3.12-minimal","status":"complete","outcome":"passed","runTime":3270.681208,"created":"2026-06-02T08:19:38.223443","updated":"2026-06-02T08:19:38.223451","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/773d0466-8451-4410-be2e-6a1353731082\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/773d0466-8451-4410-be2e-6a1353731082/pipeline.log\">pipeline</a>"]},{"id":"65ca43e8-29fc-47f7-b518-a12cd7217042","name":"RHEL9 - PyTest - 3.14-minimal","status":"complete","outcome":"passed","runTime":3407.251586,"created":"2026-06-02T08:19:37.995553","updated":"2026-06-02T08:19:37.995561","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/65ca43e8-29fc-47f7-b518-a12cd7217042\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/65ca43e8-29fc-47f7-b518-a12cd7217042/pipeline.log\">pipeline</a>"]},{"id":"fa39ef18-8b73-4661-b513-bafba3e91c60","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2095.656345,"created":"2026-06-03T11:32:16.841873","updated":"2026-06-03T11:32:16.841878","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa39ef18-8b73-4661-b513-bafba3e91c60\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/fa39ef18-8b73-4661-b513-bafba3e91c60/pipeline.log\">pipeline</a>"]},{"id":"c464a58c-9924-4e64-8f5d-4c104ab0ee24","name":"RHEL8 - 3.12","status":"complete","outcome":"passed","runTime":3390.425264,"created":"2026-06-02T08:19:38.588199","updated":"2026-06-02T08:19:38.588206","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c464a58c-9924-4e64-8f5d-4c104ab0ee24\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c464a58c-9924-4e64-8f5d-4c104ab0ee24/pipeline.log\">pipeline</a>"]},{"id":"1df56fb9-a98c-488e-8ed2-e0ec2707a292","name":"RHEL8 - 3.11-minimal","status":"complete","outcome":"passed","runTime":3512.459124,"created":"2026-06-02T08:19:37.938194","updated":"2026-06-02T08:19:37.938201","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1df56fb9-a98c-488e-8ed2-e0ec2707a292\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1df56fb9-a98c-488e-8ed2-e0ec2707a292/pipeline.log\">pipeline</a>"]},{"id":"ba3e3a28-fe12-4509-a9c8-7a5b687bdf5c","name":"RHEL9 - Unsubscribed host - 3.9","status":"complete","outcome":"passed","runTime":2021.322974,"created":"2026-06-03T11:57:49.272620","updated":"2026-06-03T11:57:49.272627","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba3e3a28-fe12-4509-a9c8-7a5b687bdf5c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ba3e3a28-fe12-4509-a9c8-7a5b687bdf5c/pipeline.log\">pipeline</a>"]},{"id":"c815e769-00bc-4211-85c7-8a47b400422e","name":"RHEL9 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1931.328676,"created":"2026-06-03T11:27:09.345873","updated":"2026-06-03T11:27:09.345882","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c815e769-00bc-4211-85c7-8a47b400422e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c815e769-00bc-4211-85c7-8a47b400422e/pipeline.log\">pipeline</a>"]},{"id":"9f13d35a-7204-45cf-8f08-84e460d3194c","name":"RHEL10 - Unsubscribed host - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":1245.730128,"created":"2026-06-03T12:17:42.420793","updated":"2026-06-03T12:17:42.420799","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f13d35a-7204-45cf-8f08-84e460d3194c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9f13d35a-7204-45cf-8f08-84e460d3194c/pipeline.log\">pipeline</a>"]},{"id":"2d805135-12be-453b-9751-2e5876d88309","name":"CentOS Stream 10 - 3.13","status":"complete","outcome":"passed","runTime":1317.215798,"created":"2026-06-02T08:59:08.938365","updated":"2026-06-02T08:59:08.938374","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2d805135-12be-453b-9751-2e5876d88309\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2d805135-12be-453b-9751-2e5876d88309/pipeline.log\">pipeline</a>"]},{"id":"843e9c5e-c2b5-4b6d-b73a-735e899c4e1b","name":"RHEL8 - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":1676.41922,"created":"2026-06-03T12:02:30.879470","updated":"2026-06-03T12:02:30.879476","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/843e9c5e-c2b5-4b6d-b73a-735e899c4e1b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/843e9c5e-c2b5-4b6d-b73a-735e899c4e1b/pipeline.log\">pipeline</a>"]},{"id":"b0c5775e-d0a4-4359-ba6c-07aea9860e34","name":"RHEL9 - PyTest - 3.11","status":"complete","outcome":"passed","runTime":3800.281093,"created":"2026-06-02T08:19:38.771601","updated":"2026-06-02T08:19:38.771609","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0c5775e-d0a4-4359-ba6c-07aea9860e34\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b0c5775e-d0a4-4359-ba6c-07aea9860e34/pipeline.log\">pipeline</a>"]},{"id":"0d7aaaa1-fa99-4dab-84a3-29a1ee8e6de2","name":"RHEL9 - Unsubscribed host - PyTest - 3.12","status":"complete","outcome":"passed","runTime":2273.436168,"created":"2026-06-03T12:05:45.949874","updated":"2026-06-03T12:05:45.949880","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d7aaaa1-fa99-4dab-84a3-29a1ee8e6de2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0d7aaaa1-fa99-4dab-84a3-29a1ee8e6de2/pipeline.log\">pipeline</a>"]},{"id":"3e2e0071-1915-4f3f-a158-0cdfe094eadd","name":"RHEL9 - Unsubscribed host - PyTest - 3.11","status":"complete","outcome":"error","runTime":3865.313076,"created":"2026-06-02T08:19:38.140661","updated":"2026-06-02T08:19:38.140667","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e2e0071-1915-4f3f-a158-0cdfe094eadd\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3e2e0071-1915-4f3f-a158-0cdfe094eadd/pipeline.log\">pipeline</a>"]},{"id":"c3dc2c92-7009-4cc6-8646-3e923467847d","name":"RHEL9 - Unsubscribed host - PyTest - 3.14","status":"complete","outcome":"passed","runTime":3969.70023,"created":"2026-06-02T08:19:38.083529","updated":"2026-06-02T08:19:38.083536","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3dc2c92-7009-4cc6-8646-3e923467847d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/c3dc2c92-7009-4cc6-8646-3e923467847d/pipeline.log\">pipeline</a>"]},{"id":"862487f8-9320-4079-8b18-dbefbf7d82ba","name":"RHEL9 - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":2732.218056,"created":"2026-06-02T08:42:14.734474","updated":"2026-06-02T08:42:14.734484","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/862487f8-9320-4079-8b18-dbefbf7d82ba\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/862487f8-9320-4079-8b18-dbefbf7d82ba/pipeline.log\">pipeline</a>"]},{"id":"6f2d9ca7-86a2-438c-9498-54ff68c55b5b","name":"RHEL9 - PyTest - 3.14","status":"complete","outcome":"passed","runTime":2464.672307,"created":"2026-06-03T12:01:20.671956","updated":"2026-06-03T12:01:20.671965","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f2d9ca7-86a2-438c-9498-54ff68c55b5b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6f2d9ca7-86a2-438c-9498-54ff68c55b5b/pipeline.log\">pipeline</a>"]},{"id":"d0db0e83-572f-4733-8bdb-764f2c90dd7b","name":"CentOS Stream 9 - PyTest - 3.11-minimal","status":"complete","outcome":"passed","runTime":943.424555,"created":"2026-06-02T09:20:01.049674","updated":"2026-06-02T09:20:01.049681","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/d0db0e83-572f-4733-8bdb-764f2c90dd7b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/d0db0e83-572f-4733-8bdb-764f2c90dd7b/pipeline.log\">pipeline</a>"]},{"id":"b007cf8e-1324-48c1-9767-9731b95fc89c","name":"CentOS Stream 10 - PyTest - 3.13-minimal","status":"complete","outcome":"passed","runTime":928.88359,"created":"2026-06-03T12:01:19.548060","updated":"2026-06-03T12:01:19.548069","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b007cf8e-1324-48c1-9767-9731b95fc89c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b007cf8e-1324-48c1-9767-9731b95fc89c/pipeline.log\">pipeline</a>"]},{"id":"9579aade-b1ec-43ae-b827-9cf18d793cd7","name":"Fedora - 3.14-minimal","status":"complete","outcome":"passed","runTime":892.988841,"created":"2026-06-03T12:26:53.668143","updated":"2026-06-03T12:26:53.668151","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9579aade-b1ec-43ae-b827-9cf18d793cd7\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9579aade-b1ec-43ae-b827-9cf18d793cd7/pipeline.log\">pipeline</a>"]},{"id":"f56ca73e-f547-42b6-adcf-72391db72fac","name":"RHEL9 - PyTest - 3.12","status":"complete","outcome":"passed","runTime":1704.874067,"created":"2026-06-03T11:27:06.129006","updated":"2026-06-03T11:27:06.129012","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f56ca73e-f547-42b6-adcf-72391db72fac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f56ca73e-f547-42b6-adcf-72391db72fac/pipeline.log\">pipeline</a>"]},{"id":"065e629e-4138-4a4b-9427-6fc45d91c893","name":"Fedora - PyTest - 3.14-minimal","status":"complete","outcome":"passed","runTime":598.873662,"created":"2026-06-03T11:27:07.788656","updated":"2026-06-03T11:27:07.788662","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/065e629e-4138-4a4b-9427-6fc45d91c893\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/065e629e-4138-4a4b-9427-6fc45d91c893/pipeline.log\">pipeline</a>"]},{"id":"28f073b6-7eff-4b6a-ae31-4014cc97791f","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1315.83711,"created":"2026-06-03T11:57:51.900557","updated":"2026-06-03T11:57:51.900580","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/28f073b6-7eff-4b6a-ae31-4014cc97791f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/28f073b6-7eff-4b6a-ae31-4014cc97791f/pipeline.log\">pipeline</a>"]},{"id":"adaa5191-3098-4c0e-baea-ef112d297f02","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1191.069104,"created":"2026-06-03T11:56:13.396346","updated":"2026-06-03T11:56:13.396352","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/adaa5191-3098-4c0e-baea-ef112d297f02\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/adaa5191-3098-4c0e-baea-ef112d297f02/pipeline.log\">pipeline</a>"]},{"id":"91c74834-9f31-4363-9fe5-0affea49f5c8","name":"CentOS Stream 9 - PyTest - 3.12","status":"complete","outcome":"passed","runTime":1107.630396,"created":"2026-06-03T12:17:44.642336","updated":"2026-06-03T12:17:44.642344","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/91c74834-9f31-4363-9fe5-0affea49f5c8\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/91c74834-9f31-4363-9fe5-0affea49f5c8/pipeline.log\">pipeline</a>"]},{"id":"06ceaffc-cc44-4a9a-97e1-f4e7f68dac96","name":"Fedora - PyTest - 3.14","status":"complete","outcome":"passed","runTime":948.651043,"created":"2026-06-02T09:28:35.957345","updated":"2026-06-02T09:28:35.957353","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/06ceaffc-cc44-4a9a-97e1-f4e7f68dac96\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/06ceaffc-cc44-4a9a-97e1-f4e7f68dac96/pipeline.log\">pipeline</a>"]},{"id":"1bd7b462-50d3-4a93-909b-e5e260bb150c","name":"RHEL9 - Unsubscribed host - 3.11","status":"complete","outcome":"passed","runTime":1928.936772,"created":"2026-06-02T09:12:08.262185","updated":"2026-06-02T09:12:08.262194","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bd7b462-50d3-4a93-909b-e5e260bb150c\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1bd7b462-50d3-4a93-909b-e5e260bb150c/pipeline.log\">pipeline</a>"]},{"id":"e8c3b0e1-17b4-4435-b0de-008c17812bdb","name":"RHEL9 - Unsubscribed host - 3.14","status":"complete","outcome":"passed","runTime":1975.997435,"created":"2026-06-03T11:27:07.970180","updated":"2026-06-03T11:27:07.970187","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8c3b0e1-17b4-4435-b0de-008c17812bdb\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e8c3b0e1-17b4-4435-b0de-008c17812bdb/pipeline.log\">pipeline</a>"]},{"id":"962e7e6d-cd3d-44f9-b6d1-9e8fa47a480f","name":"RHEL8 - PyTest - 3.12","status":"complete","outcome":"passed","runTime":1371.121525,"created":"2026-06-03T11:38:16.085083","updated":"2026-06-03T11:38:16.085089","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/962e7e6d-cd3d-44f9-b6d1-9e8fa47a480f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/962e7e6d-cd3d-44f9-b6d1-9e8fa47a480f/pipeline.log\">pipeline</a>"]},{"id":"76ae74f2-2c40-4fb8-b618-9666cf6ec2ed","name":"RHEL9 - Unsubscribed host - 3.12-minimal","status":"complete","outcome":"passed","runTime":2040.920061,"created":"2026-06-03T12:01:30.412554","updated":"2026-06-03T12:01:30.412561","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/76ae74f2-2c40-4fb8-b618-9666cf6ec2ed\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/76ae74f2-2c40-4fb8-b618-9666cf6ec2ed/pipeline.log\">pipeline</a>"]},{"id":"9c90d8bd-9bc8-419b-b166-2d750df2e1a9","name":"CentOS Stream 10 - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":833.10693,"created":"2026-06-03T11:27:07.580540","updated":"2026-06-03T11:27:07.580548","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9c90d8bd-9bc8-419b-b166-2d750df2e1a9\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9c90d8bd-9bc8-419b-b166-2d750df2e1a9/pipeline.log\">pipeline</a>"]},{"id":"6a539dac-756d-40af-84c6-881724abf47b","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1191.971973,"created":"2026-06-02T09:36:25.556958","updated":"2026-06-02T09:36:25.556964","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6a539dac-756d-40af-84c6-881724abf47b\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6a539dac-756d-40af-84c6-881724abf47b/pipeline.log\">pipeline</a>"]},{"id":"59d651a5-0ff0-40ab-a5e0-e6e703b4f9a3","name":"RHEL9 - PyTest - 3.9","status":"complete","outcome":"passed","runTime":1731.990146,"created":"2026-06-03T11:27:06.802435","updated":"2026-06-03T11:27:06.802440","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/59d651a5-0ff0-40ab-a5e0-e6e703b4f9a3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/59d651a5-0ff0-40ab-a5e0-e6e703b4f9a3/pipeline.log\">pipeline</a>"]},{"id":"0ad3fcf7-f58b-402d-9273-3c13d48156b7","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1563.008257,"created":"2026-06-03T11:27:07.671358","updated":"2026-06-03T11:27:07.671364","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ad3fcf7-f58b-402d-9273-3c13d48156b7\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0ad3fcf7-f58b-402d-9273-3c13d48156b7/pipeline.log\">pipeline</a>"]},{"id":"5f39f9ea-1dfe-4a13-924e-ad75e370ea97","name":"RHEL9 - 3.9","status":"complete","outcome":"passed","runTime":2373.701309,"created":"2026-06-03T11:41:17.506921","updated":"2026-06-03T11:41:17.506934","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f39f9ea-1dfe-4a13-924e-ad75e370ea97\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5f39f9ea-1dfe-4a13-924e-ad75e370ea97/pipeline.log\">pipeline</a>"]},{"id":"23af4226-42ec-430f-a286-64fd4112a19f","name":"CentOS Stream 9 - 3.11","status":"complete","outcome":"error","runTime":1313.695864,"created":"2026-06-02T09:37:50.124843","updated":"2026-06-02T09:37:50.124856","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/23af4226-42ec-430f-a286-64fd4112a19f\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/23af4226-42ec-430f-a286-64fd4112a19f/pipeline.log\">pipeline</a>"]},{"id":"88c08eb1-2fa6-407e-a20b-041d81f98715","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1391.335988,"created":"2026-06-03T12:22:01.277790","updated":"2026-06-03T12:22:01.277805","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/88c08eb1-2fa6-407e-a20b-041d81f98715\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/88c08eb1-2fa6-407e-a20b-041d81f98715/pipeline.log\">pipeline</a>"]},{"id":"41a0247f-1978-44fb-b497-41e36a72648c","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1220.026906,"created":"2026-06-03T11:27:09.801199","updated":"2026-06-03T11:27:09.801206","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/41a0247f-1978-44fb-b497-41e36a72648c\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/41a0247f-1978-44fb-b497-41e36a72648c/pipeline.log\">pipeline</a>"]},{"id":"1be3a3ff-c9d9-4d56-b2f8-e015dfce1d5d","name":"Fedora - 3.13-minimal","status":"complete","outcome":"passed","runTime":954.52284,"created":"2026-06-03T12:20:12.817369","updated":"2026-06-03T12:20:12.817378","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/1be3a3ff-c9d9-4d56-b2f8-e015dfce1d5d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/1be3a3ff-c9d9-4d56-b2f8-e015dfce1d5d/pipeline.log\">pipeline</a>"]},{"id":"354e368d-8468-479d-b9ed-c16d6c68a0c4","name":"CentOS Stream 9 - PyTest - 3.11","status":"complete","outcome":"passed","runTime":1058.962977,"created":"2026-06-02T09:45:03.484272","updated":"2026-06-02T09:45:03.484282","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/354e368d-8468-479d-b9ed-c16d6c68a0c4\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/354e368d-8468-479d-b9ed-c16d6c68a0c4/pipeline.log\">pipeline</a>"]},{"id":"b20b675b-af8c-462c-85cd-b68bea4ed19f","name":"RHEL8 - PyTest - 3.11-minimal","status":"complete","outcome":"passed","runTime":1282.856174,"created":"2026-06-02T09:42:26.966798","updated":"2026-06-02T09:42:26.966805","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b20b675b-af8c-462c-85cd-b68bea4ed19f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b20b675b-af8c-462c-85cd-b68bea4ed19f/pipeline.log\">pipeline</a>"]},{"id":"4b135ac3-4541-4a07-9732-0be01896d262","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1095.402788,"created":"2026-06-03T12:26:11.284087","updated":"2026-06-03T12:26:11.284092","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/4b135ac3-4541-4a07-9732-0be01896d262\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/4b135ac3-4541-4a07-9732-0be01896d262/pipeline.log\">pipeline</a>"]},{"id":"f6ffa3a1-0ae4-482e-94b2-6e53983f0ef6","name":"RHEL8 - 3.11","status":"complete","outcome":"passed","runTime":1625.89494,"created":"2026-06-02T09:42:54.676280","updated":"2026-06-02T09:42:54.676286","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6ffa3a1-0ae4-482e-94b2-6e53983f0ef6\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f6ffa3a1-0ae4-482e-94b2-6e53983f0ef6/pipeline.log\">pipeline</a>"]},{"id":"6cb905f4-36d8-467e-b511-1be5941d4f87","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":2137.050447,"created":"2026-06-02T09:34:58.668983","updated":"2026-06-02T09:34:58.668989","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cb905f4-36d8-467e-b511-1be5941d4f87\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6cb905f4-36d8-467e-b511-1be5941d4f87/pipeline.log\">pipeline</a>"]},{"id":"6f832fd2-5188-462e-a924-f5f35e38ff23","name":"CentOS Stream 10 - PyTest - 3.14-minimal","status":"complete","outcome":"passed","runTime":758.918792,"created":"2026-06-03T11:57:27.673222","updated":"2026-06-03T11:57:27.673230","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6f832fd2-5188-462e-a924-f5f35e38ff23\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6f832fd2-5188-462e-a924-f5f35e38ff23/pipeline.log\">pipeline</a>"]},{"id":"734505f6-cdc0-4337-864f-4e9dd3dc1d88","name":"RHEL9 - 3.14","status":"complete","outcome":"passed","runTime":2028.759388,"created":"2026-06-02T09:39:14.825403","updated":"2026-06-02T09:39:14.825411","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/734505f6-cdc0-4337-864f-4e9dd3dc1d88\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/734505f6-cdc0-4337-864f-4e9dd3dc1d88/pipeline.log\">pipeline</a>"]},{"id":"8e102384-1c12-4b88-a758-688089e29480","name":"RHEL9 - Unsubscribed host - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":1659.430794,"created":"2026-06-03T11:58:31.193704","updated":"2026-06-03T11:58:31.193711","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e102384-1c12-4b88-a758-688089e29480\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8e102384-1c12-4b88-a758-688089e29480/pipeline.log\">pipeline</a>"]},{"id":"e4fe29a4-f9cb-43de-9582-3cf8f21a3ec0","name":"RHEL9 - Unsubscribed host - 3.12","status":"complete","outcome":"passed","runTime":2050.814235,"created":"2026-06-03T12:02:40.299565","updated":"2026-06-03T12:02:40.299571","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4fe29a4-f9cb-43de-9582-3cf8f21a3ec0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/e4fe29a4-f9cb-43de-9582-3cf8f21a3ec0/pipeline.log\">pipeline</a>"]},{"id":"8d3be929-0a10-447b-8306-64298b9c196d","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1636.511297,"created":"2026-06-02T09:46:35.894606","updated":"2026-06-02T09:46:35.894614","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d3be929-0a10-447b-8306-64298b9c196d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/8d3be929-0a10-447b-8306-64298b9c196d/pipeline.log\">pipeline</a>"]},{"id":"c489188a-5cfc-44ce-a1d7-2a47d7090a5e","name":"CentOS Stream 9 - PyTest - 3.9","status":"complete","outcome":"passed","runTime":1093.572495,"created":"2026-06-03T12:01:40.961278","updated":"2026-06-03T12:01:40.961288","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c489188a-5cfc-44ce-a1d7-2a47d7090a5e\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c489188a-5cfc-44ce-a1d7-2a47d7090a5e/pipeline.log\">pipeline</a>"]},{"id":"214ee4fb-58bc-45f3-87c5-5de2b1367b74","name":"CentOS Stream 9 - PyTest - 3.14-minimal","status":"complete","outcome":"passed","runTime":988.089481,"created":"2026-06-03T12:07:48.244070","updated":"2026-06-03T12:07:48.244077","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/214ee4fb-58bc-45f3-87c5-5de2b1367b74\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/214ee4fb-58bc-45f3-87c5-5de2b1367b74/pipeline.log\">pipeline</a>"]},{"id":"6da874be-f30b-4f62-bf99-5058aec9d026","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1298.827421,"created":"2026-06-02T09:55:04.071630","updated":"2026-06-02T09:55:04.071636","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/6da874be-f30b-4f62-bf99-5058aec9d026\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/6da874be-f30b-4f62-bf99-5058aec9d026/pipeline.log\">pipeline</a>"]},{"id":"d257c72a-d2f6-4070-a97f-7db17ea0fd3b","name":"RHEL10 - Unsubscribed host - PyTest - 3.14-minimal","status":"complete","outcome":"error","runTime":1235.0869,"created":"2026-06-03T11:27:06.412787","updated":"2026-06-03T11:27:06.412794","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d257c72a-d2f6-4070-a97f-7db17ea0fd3b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d257c72a-d2f6-4070-a97f-7db17ea0fd3b/pipeline.log\">pipeline</a>"]},{"id":"ed540a75-4bf2-496c-995f-41c8fa947096","name":"RHEL9 - 3.11","status":"complete","outcome":"passed","runTime":1951.987739,"created":"2026-06-02T09:44:35.576706","updated":"2026-06-02T09:44:35.576713","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed540a75-4bf2-496c-995f-41c8fa947096\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/ed540a75-4bf2-496c-995f-41c8fa947096/pipeline.log\">pipeline</a>"]},{"id":"f2208648-6d5a-477d-89f3-8f6a89510419","name":"CentOS Stream 10 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1180.694837,"created":"2026-06-02T09:58:46.519884","updated":"2026-06-02T09:58:46.519892","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f2208648-6d5a-477d-89f3-8f6a89510419\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f2208648-6d5a-477d-89f3-8f6a89510419/pipeline.log\">pipeline</a>"]},{"id":"06c6116c-cb8b-401d-9a0d-288d32e53932","name":"CentOS Stream 9 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1208.829691,"created":"2026-06-03T12:11:53.289076","updated":"2026-06-03T12:11:53.289085","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/06c6116c-cb8b-401d-9a0d-288d32e53932\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/06c6116c-cb8b-401d-9a0d-288d32e53932/pipeline.log\">pipeline</a>"]},{"id":"369faf69-b375-447d-a57d-3414a265d4a0","name":"RHEL9 - Unsubscribed host - 3.14-minimal","status":"complete","outcome":"error","runTime":1738.491523,"created":"2026-06-03T10:22:28.436250","updated":"2026-06-03T10:22:28.436258","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/369faf69-b375-447d-a57d-3414a265d4a0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/369faf69-b375-447d-a57d-3414a265d4a0/pipeline.log\">pipeline</a>"]},{"id":"2ca69017-c8b8-498c-9944-2e6459860d0d","name":"RHEL10 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1697.716723,"created":"2026-06-02T10:02:00.379737","updated":"2026-06-02T10:02:00.379744","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ca69017-c8b8-498c-9944-2e6459860d0d\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2ca69017-c8b8-498c-9944-2e6459860d0d/pipeline.log\">pipeline</a>"]},{"id":"3138d452-fccc-4ff0-8662-8fdaed974f4f","name":"RHEL10 - Unsubscribed host - 3.14-minimal","status":"complete","outcome":"passed","runTime":1732.834687,"created":"2026-06-02T10:03:23.855861","updated":"2026-06-02T10:03:23.855866","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/3138d452-fccc-4ff0-8662-8fdaed974f4f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/3138d452-fccc-4ff0-8662-8fdaed974f4f/pipeline.log\">pipeline</a>"]},{"id":"4f9ba14d-b8f1-4ab0-93ca-eece4b0a5623","name":"RHEL9 - Unsubscribed host - PyTest - 3.14-minimal","status":"complete","outcome":"error","runTime":1651.301662,"created":"2026-06-03T11:27:06.786971","updated":"2026-06-03T11:27:06.786979","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f9ba14d-b8f1-4ab0-93ca-eece4b0a5623\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/4f9ba14d-b8f1-4ab0-93ca-eece4b0a5623/pipeline.log\">pipeline</a>"]},{"id":"f4f80b9e-0d59-4a88-aa47-dd9b9451853b","name":"RHEL10 - PyTest - 3.14-minimal","status":"complete","outcome":"passed","runTime":1716.915332,"created":"2026-06-02T10:04:52.881313","updated":"2026-06-02T10:04:52.881319","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4f80b9e-0d59-4a88-aa47-dd9b9451853b\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/f4f80b9e-0d59-4a88-aa47-dd9b9451853b/pipeline.log\">pipeline</a>"]},{"id":"ee13639f-ebbe-42e3-a1fc-dba9c1d5bec6","name":"CentOS Stream 9 - PyTest - 3.14","status":"complete","outcome":"passed","runTime":1172.104053,"created":"2026-06-03T12:16:36.409332","updated":"2026-06-03T12:16:36.409340","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/ee13639f-ebbe-42e3-a1fc-dba9c1d5bec6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/ee13639f-ebbe-42e3-a1fc-dba9c1d5bec6/pipeline.log\">pipeline</a>"]},{"id":"2148108d-b1da-4868-b3b4-7bb577abd2f1","name":"RHEL10 - PyTest - 3.12-minimal","status":"complete","outcome":"passed","runTime":1333.874504,"created":"2026-06-03T10:24:05.959535","updated":"2026-06-03T10:24:05.959548","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/2148108d-b1da-4868-b3b4-7bb577abd2f1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/2148108d-b1da-4868-b3b4-7bb577abd2f1/pipeline.log\">pipeline</a>"]},{"id":"6bc19ac2-9146-4e62-945c-3e18101ddda3","name":"RHEL9 - Unsubscribed host - PyTest - 3.9","status":"complete","outcome":"passed","runTime":2245.95022,"created":"2026-06-03T12:01:54.077560","updated":"2026-06-03T12:01:54.077567","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bc19ac2-9146-4e62-945c-3e18101ddda3\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/6bc19ac2-9146-4e62-945c-3e18101ddda3/pipeline.log\">pipeline</a>"]}]} -->