### PR TITLE
Add RHEL App Streams lifecycle information to READMEs

### DIFF
--- a/3.12-minimal/README.md
+++ b/3.12-minimal/README.md
@@ -28,6 +28,8 @@ of installed packages. There are no compilers, no header files, no npm etc and t
 reimplementation called microdnf, making the resulting container images much smaller. This creates some limitations
 but we provide ways to workaround them.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Limitations
 -----------
 

--- a/3.12/README.md
+++ b/3.12/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 

--- a/3.13-minimal/README.md
+++ b/3.13-minimal/README.md
@@ -28,6 +28,8 @@ of installed packages. There are no compilers, no header files, no npm etc and t
 reimplementation called microdnf, making the resulting container images much smaller. This creates some limitations
 but we provide ways to workaround them.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Limitations
 -----------
 

--- a/3.13/README.md
+++ b/3.13/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 

--- a/3.14-minimal/README.md
+++ b/3.14-minimal/README.md
@@ -28,6 +28,8 @@ of installed packages. There are no compilers, no header files, no npm etc and t
 reimplementation called microdnf, making the resulting container images much smaller. This creates some limitations
 but we provide ways to workaround them.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Limitations
 -----------
 

--- a/3.14/README.md
+++ b/3.14/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 

--- a/3.6/README.md
+++ b/3.6/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 

--- a/3.9-minimal/README.md
+++ b/3.9-minimal/README.md
@@ -28,6 +28,8 @@ of installed packages. There are no compilers, no header files, no npm etc and t
 reimplementation called microdnf, making the resulting container images much smaller. This creates some limitations
 but we provide ways to workaround them.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Limitations
 -----------
 

--- a/3.9/README.md
+++ b/3.9/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Table start
 Table end
 -->
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Download
 --------
 To download one of the base Python images, follow the instructions you find in registries mentioned above.

--- a/src/README-minimal.md
+++ b/src/README-minimal.md
@@ -29,6 +29,8 @@ of installed packages. There are no compilers, no header files, no npm etc and t
 reimplementation called microdnf, making the resulting container images much smaller. This creates some limitations
 but we provide ways to workaround them.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Limitations
 -----------
 

--- a/src/README.md
+++ b/src/README.md
@@ -29,6 +29,8 @@ modules for their web applications. There is no guarantee for any specific npm o
 version, that is included in the image; those versions can be changed anytime and
 the nodejs itself is included just to make the npm work.
 
+See [the Red Hat Enterprise Linux Application Streams Life Cycle page](https://access.redhat.com/support/policy/updates/rhel-app-streams-life-cycle) for information about support for a particular stream.
+
 Usage in Openshift
 ------------------
 


### PR DESCRIPTION
Add reference to the Red Hat Enterprise Linux Application Streams Life Cycle page in the main README and all version-specific READMEs to provide users with information about support lifecycle for each Python stream.

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across all Python version container image guides to include references to Red Hat Enterprise Linux Application Streams Life Cycle information, enabling users to easily access support timelines and lifecycle details for their specific Python version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- testing-farm = {"lock":"false","comment-id":"4720111261","data":[{"id":"e67943d2-8d32-4585-a373-0a9e9fd889a6","name":"CentOS Stream 10 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1235.014303,"created":"2026-06-16T14:30:17.337505","updated":"2026-06-16T14:30:17.337513","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e67943d2-8d32-4585-a373-0a9e9fd889a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e67943d2-8d32-4585-a373-0a9e9fd889a6/pipeline.log\">pipeline</a>"]},{"id":"d61e030b-d03b-492f-9399-2d9c22373249","name":"RHEL10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1606.800749,"created":"2026-06-16T14:30:07.865842","updated":"2026-06-16T14:30:07.865851","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/d61e030b-d03b-492f-9399-2d9c22373249\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/d61e030b-d03b-492f-9399-2d9c22373249/pipeline.log\">pipeline</a>"]},{"id":"2b905327-4dce-403e-a799-31558519ca10","name":"Fedora - 3.13-minimal","status":"complete","outcome":"passed","runTime":1124.380748,"created":"2026-06-16T14:45:13.921339","updated":"2026-06-16T14:45:13.921348","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/2b905327-4dce-403e-a799-31558519ca10\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/2b905327-4dce-403e-a799-31558519ca10/pipeline.log\">pipeline</a>"]},{"id":"b9515f97-a363-463d-aa8a-ee8f3450fe91","name":"Fedora - 3.14","status":"complete","outcome":"passed","runTime":1283.45278,"created":"2026-06-16T14:45:14.376516","updated":"2026-06-16T14:45:14.376528","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b9515f97-a363-463d-aa8a-ee8f3450fe91\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b9515f97-a363-463d-aa8a-ee8f3450fe91/pipeline.log\">pipeline</a>"]},{"id":"f22f2855-7586-4be7-96e2-bf9d8575391d","name":"CentOS Stream 10 - 3.13","status":"complete","outcome":"passed","runTime":1308.114507,"created":"2026-06-16T14:45:19.206709","updated":"2026-06-16T14:45:19.206718","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f22f2855-7586-4be7-96e2-bf9d8575391d\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f22f2855-7586-4be7-96e2-bf9d8575391d/pipeline.log\">pipeline</a>"]},{"id":"0f8fc463-7181-4368-9f3b-6de0e4c0bf02","name":"RHEL9 - Unsubscribed host - 3.14-minimal","status":"complete","outcome":"passed","runTime":1666.191485,"created":"2026-06-16T14:43:11.241074","updated":"2026-06-16T14:43:11.241080","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f8fc463-7181-4368-9f3b-6de0e4c0bf02\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/0f8fc463-7181-4368-9f3b-6de0e4c0bf02/pipeline.log\">pipeline</a>"]},{"id":"9a3f9703-20a7-4c70-b2c6-96561dd369c0","name":"RHEL10 - Unsubscribed host - 3.12-minimal","status":"complete","outcome":"passed","runTime":1525.490269,"created":"2026-06-16T14:45:11.637890","updated":"2026-06-16T14:45:11.637931","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a3f9703-20a7-4c70-b2c6-96561dd369c0\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/9a3f9703-20a7-4c70-b2c6-96561dd369c0/pipeline.log\">pipeline</a>"]},{"id":"b6d77a87-d230-43d2-acf7-74f02715ebac","name":"RHEL8 - 3.12","status":"complete","outcome":"error","runTime":1833.141692,"created":"2026-06-16T14:45:05.807160","updated":"2026-06-16T14:45:05.807167","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d77a87-d230-43d2-acf7-74f02715ebac\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b6d77a87-d230-43d2-acf7-74f02715ebac/pipeline.log\">pipeline</a>"]},{"id":"faf9fbae-d60f-4bb7-b824-383faa27b4a8","name":"RHEL9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":2095.936007,"created":"2026-06-16T14:45:26.212886","updated":"2026-06-16T14:45:26.212894","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/faf9fbae-d60f-4bb7-b824-383faa27b4a8\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/faf9fbae-d60f-4bb7-b824-383faa27b4a8/pipeline.log\">pipeline</a>"]},{"id":"962b0fe7-21c8-4553-91fb-19367f7b7812","name":"RHEL9 - Unsubscribed host - 3.12","status":"complete","outcome":"passed","runTime":1880.650629,"created":"2026-06-16T14:52:51.780145","updated":"2026-06-16T14:52:51.780154","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/962b0fe7-21c8-4553-91fb-19367f7b7812\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/962b0fe7-21c8-4553-91fb-19367f7b7812/pipeline.log\">pipeline</a>"]},{"id":"e07368cb-80ef-4a27-9866-09a92986547a","name":"Fedora - 3.13","status":"complete","outcome":"passed","runTime":1191.21238,"created":"2026-06-16T15:07:38.789215","updated":"2026-06-16T15:07:38.789225","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/e07368cb-80ef-4a27-9866-09a92986547a\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/e07368cb-80ef-4a27-9866-09a92986547a/pipeline.log\">pipeline</a>"]},{"id":"efeb8b49-1120-46d8-8aea-50b09da2e6e0","name":"Fedora - 3.14-minimal","status":"complete","outcome":"passed","runTime":1197.793712,"created":"2026-06-16T15:07:45.658025","updated":"2026-06-16T15:07:45.658033","compose":"Fedora-latest","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/efeb8b49-1120-46d8-8aea-50b09da2e6e0\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/efeb8b49-1120-46d8-8aea-50b09da2e6e0/pipeline.log\">pipeline</a>"]},{"id":"3320a925-1404-4b82-84cb-1ff59f29d352","name":"CentOS Stream 10 - 3.13-minimal","status":"complete","outcome":"passed","runTime":1170.544957,"created":"2026-06-16T15:07:43.406962","updated":"2026-06-16T15:07:43.406968","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/3320a925-1404-4b82-84cb-1ff59f29d352\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/3320a925-1404-4b82-84cb-1ff59f29d352/pipeline.log\">pipeline</a>"]},{"id":"761ae6af-df23-4c16-b862-62320dc0c805","name":"CentOS Stream 9 - 3.9-minimal","status":"complete","outcome":"passed","runTime":1308.425493,"created":"2026-06-16T15:07:42.109406","updated":"2026-06-16T15:07:42.109414","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/761ae6af-df23-4c16-b862-62320dc0c805\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/761ae6af-df23-4c16-b862-62320dc0c805/pipeline.log\">pipeline</a>"]},{"id":"5904bd70-b83d-425b-afad-b786f65a2d46","name":"CentOS Stream 10 - 3.12","status":"complete","outcome":"passed","runTime":1286.017188,"created":"2026-06-16T15:07:43.035765","updated":"2026-06-16T15:07:43.035776","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/5904bd70-b83d-425b-afad-b786f65a2d46\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/5904bd70-b83d-425b-afad-b786f65a2d46/pipeline.log\">pipeline</a>"]},{"id":"bece02f6-5111-492b-964a-610f1fc2b834","name":"CentOS Stream 9 - 3.12","status":"complete","outcome":"passed","runTime":1356.675579,"created":"2026-06-16T15:07:42.252956","updated":"2026-06-16T15:07:42.252964","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/bece02f6-5111-492b-964a-610f1fc2b834\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/bece02f6-5111-492b-964a-610f1fc2b834/pipeline.log\">pipeline</a>"]},{"id":"f75dc0bb-41c2-4190-835a-c7b7032926a6","name":"CentOS Stream 9 - 3.9","status":"complete","outcome":"passed","runTime":1420.020616,"created":"2026-06-16T15:07:44.677237","updated":"2026-06-16T15:07:44.677244","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/f75dc0bb-41c2-4190-835a-c7b7032926a6\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/f75dc0bb-41c2-4190-835a-c7b7032926a6/pipeline.log\">pipeline</a>"]},{"id":"cf7d8432-bd47-4d8f-a81c-1e03da8641c1","name":"RHEL9 - Unsubscribed host - 3.14","status":"complete","outcome":"passed","runTime":2022.976964,"created":"2026-06-16T14:58:45.409428","updated":"2026-06-16T14:58:45.409436","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf7d8432-bd47-4d8f-a81c-1e03da8641c1\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cf7d8432-bd47-4d8f-a81c-1e03da8641c1/pipeline.log\">pipeline</a>"]},{"id":"9f91c00e-2a26-4a16-a657-22d6bdeeaf33","name":"CentOS Stream 9 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1234.777405,"created":"2026-06-16T15:11:56.900554","updated":"2026-06-16T15:11:56.900564","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/9f91c00e-2a26-4a16-a657-22d6bdeeaf33\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/9f91c00e-2a26-4a16-a657-22d6bdeeaf33/pipeline.log\">pipeline</a>"]},{"id":"b005b2e5-e0d3-4ca5-92f5-4ca6a1f843b1","name":"CentOS Stream 10 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1201.381801,"created":"2026-06-16T15:17:30.128042","updated":"2026-06-16T15:17:30.128058","compose":"CentOS-Stream-10","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/b005b2e5-e0d3-4ca5-92f5-4ca6a1f843b1\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/b005b2e5-e0d3-4ca5-92f5-4ca6a1f843b1/pipeline.log\">pipeline</a>"]},{"id":"b7816d95-b074-4831-bca3-d74db4bf0fae","name":"RHEL10 - Unsubscribed host - 3.14-minimal","status":"complete","outcome":"passed","runTime":1915.993087,"created":"2026-06-16T15:07:37.692193","updated":"2026-06-16T15:07:37.692201","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b7816d95-b074-4831-bca3-d74db4bf0fae\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b7816d95-b074-4831-bca3-d74db4bf0fae/pipeline.log\">pipeline</a>"]},{"id":"cabe5020-da1a-4fad-bf7f-79ae8b6cc438","name":"RHEL10 - 3.14-minimal","status":"complete","outcome":"passed","runTime":2096.469524,"created":"2026-06-16T15:07:49.446554","updated":"2026-06-16T15:07:49.446561","compose":"RHEL-10.2-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/cabe5020-da1a-4fad-bf7f-79ae8b6cc438\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/cabe5020-da1a-4fad-bf7f-79ae8b6cc438/pipeline.log\">pipeline</a>"]},{"id":"7b5a8595-b96d-48d6-96ea-00cf50ffdf9f","name":"RHEL9 - Unsubscribed host - 3.9","status":"complete","outcome":"passed","runTime":2351.019165,"created":"2026-06-16T15:07:39.760332","updated":"2026-06-16T15:07:39.760341","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b5a8595-b96d-48d6-96ea-00cf50ffdf9f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/7b5a8595-b96d-48d6-96ea-00cf50ffdf9f/pipeline.log\">pipeline</a>"]},{"id":"b84177e8-c9c1-4e3f-affb-642678814ca2","name":"RHEL9 - Unsubscribed host - 3.12-minimal","status":"complete","outcome":"passed","runTime":2457.758599,"created":"2026-06-16T15:05:48.362852","updated":"2026-06-16T15:05:48.362859","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/b84177e8-c9c1-4e3f-affb-642678814ca2\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/b84177e8-c9c1-4e3f-affb-642678814ca2/pipeline.log\">pipeline</a>"]},{"id":"1831b358-07e2-494e-91d6-3f81f15bcfbc","name":"RHEL8 - 3.12-minimal","status":"complete","outcome":"passed","runTime":1477.739835,"created":"2026-06-16T15:21:58.708079","updated":"2026-06-16T15:21:58.708093","compose":"RHEL-8.10.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/1831b358-07e2-494e-91d6-3f81f15bcfbc\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/1831b358-07e2-494e-91d6-3f81f15bcfbc/pipeline.log\">pipeline</a>"]},{"id":"a839a192-dfb5-4aee-a5d4-ea243085a564","name":"CentOS Stream 9 - 3.14","status":"complete","outcome":"passed","runTime":1404.032227,"created":"2026-06-16T15:25:28.292492","updated":"2026-06-16T15:25:28.292500","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/a839a192-dfb5-4aee-a5d4-ea243085a564\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/a839a192-dfb5-4aee-a5d4-ea243085a564/pipeline.log\">pipeline</a>"]},{"id":"c712d655-b8cc-4c1f-9f60-7cd56895ea51","name":"CentOS Stream 9 - 3.14-minimal","status":"complete","outcome":"passed","runTime":1308.833917,"created":"2026-06-16T15:28:14.125779","updated":"2026-06-16T15:28:14.125786","compose":"CentOS-Stream-9","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.dev.testing-farm.io/c712d655-b8cc-4c1f-9f60-7cd56895ea51\">test</a> ","<a href=\"https://artifacts.dev.testing-farm.io/c712d655-b8cc-4c1f-9f60-7cd56895ea51/pipeline.log\">pipeline</a>"]},{"id":"5553900b-af38-43fe-90ca-7b955885b80f","name":"RHEL9 - 3.12","status":"complete","outcome":"passed","runTime":2598.327188,"created":"2026-06-16T15:07:36.879478","updated":"2026-06-16T15:07:36.879483","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5553900b-af38-43fe-90ca-7b955885b80f\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5553900b-af38-43fe-90ca-7b955885b80f/pipeline.log\">pipeline</a>"]},{"id":"69f1359d-f999-42f8-95ca-73a425f8a6e4","name":"RHEL9 - 3.14","status":"complete","outcome":"passed","runTime":2506.621827,"created":"2026-06-16T15:11:43.112237","updated":"2026-06-16T15:11:43.112243","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/69f1359d-f999-42f8-95ca-73a425f8a6e4\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/69f1359d-f999-42f8-95ca-73a425f8a6e4/pipeline.log\">pipeline</a>"]},{"id":"5bc7e1b4-99df-48fc-9e4b-9a2cabe2a76e","name":"RHEL9 - 3.9","runTime":2266.87675,"created":"2026-06-16T15:28:12.853012","updated":"2026-06-16T15:28:12.853036","compose":"RHEL-9.8.0-Nightly","arch":"x86_64","infrastructureFailure":false,"status":"complete","outcome":"passed","results":["<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bc7e1b4-99df-48fc-9e4b-9a2cabe2a76e\">test</a> ","<a href=\"https://artifacts.osci.redhat.com/testing-farm/5bc7e1b4-99df-48fc-9e4b-9a2cabe2a76e/pipeline.log\">pipeline</a>"]}]} -->